### PR TITLE
Display selected pb-answers in student view

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Inside a fresh virtualenv, `cd` into the root folder of this repository (`xblock
 ```bash
 $ pip install -U pip wheel
 $ pip install -r requirements-test.txt
+$ pip install -r $VENV/src/xblock-sdk/requirements/base.txt
+$ pip install -r $VENV/src/xblock-sdk/requirements/test.txt
 ```
 
 You can then run the entire test suite via

--- a/eoc_journal/templates/eoc_journal.html
+++ b/eoc_journal/templates/eoc_journal.html
@@ -1,5 +1,22 @@
 {% load i18n %}
 <div class="eoc-journal-block">
+
+  {% if answer_sections %}
+  <div class="eoc-selected-answers">
+    {% for section in answer_sections %}
+      <section class='eoc-selected-answers-section'>
+        <h2>{{ section.name }}</h2>
+        {% for q in section.questions %}
+          <div class="eoc-selected-answer">
+            <h3>{{ q.question }}</h3>
+            <p>{{ q.answer }}</p>
+          </div>
+        {% endfor %}
+      </section>
+      {% endfor %}
+  </div>
+  {% endif %}
+
   <p>
     {% if key_takeaways_pdf_url %}
     <a class="key-takeaways-link" target="_blank" href="{{ key_takeaways_pdf_url }}">

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 git+https://github.com/edx/xblock-utils.git@v1.0.2#egg=xblock-utils==1.0.2
+git+https://github.com/edx/opaque-keys@0.4.0#egg=opaque-keys==0.4.0
+git+https://github.com/open-craft/problem-builder@27e2f4ba5afdefcb6a4e5fd793969e1e626a0abe#egg=problem-builder
 edx-rest-api-client==1.6.0
 -e .


### PR DESCRIPTION
I'm still working on this, but chose to send it ahead of time so we can work out
any possible issues.

This is based on Matjaz changes for OC-2734. I'll rebase this PR once his changes are committed.

Only the latest commit should be reviewed.

**Testing instructions**
- Setup a course with pb-answers and eoc-journal
- Mark at least one pb-answer in eoc-journal when running Studio
- Log into Apros, answer the pb-answer created and go to the roc-journal
- Check that you see the selected pb-answer, with the name of the section it belongs to, it's `display_name` and the `student_input`.

The journal should look like the screenshot below.
<img width="829" alt="screen shot 2017-07-02 at 18 11 16" src="https://user-images.githubusercontent.com/831084/27773535-2ac36102-5f52-11e7-878d-ca6b52ff7fec.png">

To run the integration tests, follow the updated instructions in the README (this PR).
Make sure all tests pass.



**Reviewers**
- [ ] @mtyaka 