### PR TITLE
Display pb-answer blocks in edit view for staff user to select.

### DIFF
--- a/eoc_journal/course_blocks_api.py
+++ b/eoc_journal/course_blocks_api.py
@@ -1,0 +1,55 @@
+"""
+An XBlock that allows learners to download their activity after they finish their course.
+"""
+
+from django.conf import settings
+from edx_rest_api_client.client import EdxRestApiClient
+
+try:
+    from openedx.core.lib.token_utils import JwtBuilder
+except ImportError:
+    JwtBuilder = None
+
+
+class CourseBlocksApiClient(object):
+    """
+    Object builds an API client to make calls to the LMS Grades API.
+    """
+
+    if hasattr(settings, 'LMS_ROOT_URL'):
+        API_BASE_URL = settings.LMS_ROOT_URL + '/api/courses/v1'
+    else:
+        API_BASE_URL = None
+
+    def __init__(self, user, course_id):
+        """
+        Connect to the REST API.
+        """
+        self.user = user
+        self.course_id = course_id
+        self.expires_in = getattr(settings, 'OAUTH_ID_TOKEN_EXPIRATION', 300)
+        self.client = None
+        self.connect()
+
+    def connect(self):
+        """
+        Connect to the REST API, authenticating with a JWT for the current user.
+        """
+        if JwtBuilder is None:
+            raise NotConnectedToOpenEdX("This package must be installed in an OpenEdX environment.")
+        scopes = ['profile', 'email']
+        jwt = JwtBuilder(self.user).build_token(scopes, self.expires_in)
+        self.client = EdxRestApiClient(self.API_BASE_URL, append_slash=True, jwt=jwt)
+
+    def get_blocks(self, **kwargs):
+        """
+        Fetches and returns blocks from the Course API.
+        """
+        return self.client.blocks.get(course_id=self.course_id, **kwargs)
+
+
+class NotConnectedToOpenEdX(Exception):
+    """
+    Exception to raise when not connected to OpenEdX.
+    """
+    pass

--- a/eoc_journal/eoc_journal.py
+++ b/eoc_journal/eoc_journal.py
@@ -3,17 +3,44 @@ An XBlock that allows learners to download their activity after they finish thei
 """
 
 from xblock.core import XBlock
-from xblock.fields import Scope, String
+from xblock.fields import Scope, String, List
 from xblock.fragment import Fragment
 from xblockutils.resources import ResourceLoader
 from xblockutils.studio_editable import StudioEditableXBlockMixin
 
+from .course_blocks_api import CourseBlocksApiClient
 from .utils import _
+
+try:
+    from django.contrib.auth.models import User
+except ImportError:
+    User = None
 
 
 loader = ResourceLoader(__name__)
 
 
+def provide_pb_answer_list(xblock_instance):
+    """
+    Returns a list of dicts containing information about pb-answer
+    blocks present in current course.
+
+    Used as a list value provider for the `selected_pb_answer_blocks`
+    field in the Studio.
+    """
+    blocks = xblock_instance.list_pb_answers(all_blocks=True)
+    result = []
+    for block in blocks:
+        block_name = block['display_name'] or block['name']
+        label = ' / '.join([block['section'], block['subsection'], block['unit'], block_name])
+        result.append({
+            'display_name': label,
+            'value': block['id'],
+        })
+    return result
+
+
+@XBlock.needs('user')
 class EOCJournalXBlock(StudioEditableXBlockMixin, XBlock):
     """
     An XBlock that allows learners to download their activity after they finish their course.
@@ -36,13 +63,25 @@ class EOCJournalXBlock(StudioEditableXBlockMixin, XBlock):
         scope=Scope.content,
     )
 
+    selected_pb_answer_blocks = List(
+        display_name=_("Problem Builder Freeform Answers"),
+        help=_("Select Problem Builder Freeform Answer components which you want to include in the report."),
+        default=[],
+        scope=Scope.content,
+        list_style='set',
+        list_values_provider=provide_pb_answer_list,
+    )
+
     editable_fields = (
-        "display_name",
-        "key_takeaways_pdf",
+        'display_name',
+        'key_takeaways_pdf',
+        'selected_pb_answer_blocks',
     )
 
     def student_view(self, context=None):
-        """View shown to students"""
+        """
+        View shown to students.
+        """
         context = context.copy() if context else {}
 
         key_takeaways_handle = self.key_takeaways_pdf.strip()
@@ -57,6 +96,66 @@ class EOCJournalXBlock(StudioEditableXBlockMixin, XBlock):
             self.runtime.local_resource_url(self, "public/css/eoc_journal.css")
         )
         return fragment
+
+    def list_pb_answers(self, all_blocks=False):
+        """
+        Returns a list of dicts with info about all problem builder's pb-answer
+        blocks present in the current coures.
+
+        The items are ordered in the order they appear in the course.
+        """
+        response = self._fetch_pb_answer_blocks(all_blocks)
+        blocks = response['blocks']
+        course_block = blocks[response['root']]
+        result = []
+        for section_id in course_block.get('children', []):
+            section_block = blocks[section_id]
+            for subsection_id in section_block.get('children', []):
+                subsection_block = blocks[subsection_id]
+                for unit_id in subsection_block.get('children', []):
+                    unit_block = blocks[unit_id]
+                    for pb_answer_id in unit_block.get('children', []):
+                        pb_answer_block = blocks[pb_answer_id]
+                        result.append({
+                            'section': section_block['display_name'],
+                            'subsection': subsection_block['display_name'],
+                            'unit': unit_block['display_name'],
+                            'id': pb_answer_block['id'],
+                            'name': pb_answer_block['student_view_data']['name'],
+                            'display_name': pb_answer_block['display_name'],
+                        })
+        return result
+
+    def _get_current_user(self):
+        """
+        Returns django.contrib.auth.models.User instance corresponding to the current user.
+        """
+        xblock_user = self.runtime.service(self, 'user').get_current_user()
+        user_id = xblock_user.opt_attrs['edx-platform.user_id']
+        user = User.objects.get(pk=user_id)
+        return user
+
+    def _fetch_pb_answer_blocks(self, all_blocks=False):
+        """
+        Fetches blocks from the Course API. Results are currently limited to
+        course, chapter, sequential, vetcial, and pb-answer blocks.
+
+        If `all_blocks` is True, returns all blocks, including those that are
+        visible only to specific learners (cohort groups, randomized content...).
+        Only staff users can request `all_blocks`.
+        """
+        user = self._get_current_user()
+        course_id = unicode(getattr(self.runtime, 'course_id', 'course_id'))
+        client = CourseBlocksApiClient(user, course_id)
+        response = client.get_blocks(
+            all_blocks=all_blocks,
+            depth='all',
+            requested_fields='student_view_data,children',
+            student_view_data='pb-answer',
+            block_types_filter='pb-answer,vertical,sequential,chapter,course',
+            username=user.username,
+        )
+        return response
 
     def _expand_static_url(self, url):
         """

--- a/eoc_journal/templates/eoc_journal_edit.html
+++ b/eoc_journal/templates/eoc_journal_edit.html
@@ -1,0 +1,39 @@
+{% load i18n %}
+<div class="eoc-journal-block-edit editor-with-buttons">
+  <div class="wrapper-comp-settings is-active editor-with-buttons" id="settings-tab">
+    <ul class="list-input settings-list">
+      {% for field in fields %}
+        <li class="field comp-setting-entry metadata_entry field-{{ field.name }}">
+          <div class="wrapper-comp-setting">
+            <label class="label setting-label" for="xb-field-edit-{{ field.name }}">
+              {{ field.display_name }}
+            </label>
+            {% if field.name == 'selected_pb_answer_blocks' %}
+              <span class="fa fa-spinner fa-spin"></span>
+            {% else %}
+              <input
+                class="field-data-control"
+                type="text"
+                name="{{ field.name }}"
+                id="xb-field-edit-{{ field.name }}"
+                value="{{ field.value | default_if_none:'' }}"
+              >
+            {% endif %}
+          </div>
+          <span class="tip setting-help"> {{ field.help | safe }} </span>
+        </li>
+      {% endfor %}
+    </ul>
+  </div>
+  <div class="xblock-actions">
+    <ul>
+      <li class="action-item">
+        <a href="#" class="button action-primary save-button">{% trans "Save" %}</a>
+      </li>
+
+      <li class="action-item">
+        <a href="#" class="button cancel-button">{% trans "Cancel" %}</a>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 git+https://github.com/edx/xblock-utils.git@v1.0.2#egg=xblock-utils==1.0.2
+edx-rest-api-client==1.6.0
 -e .

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
     install_requires=[
         'XBlock',
         'xblock-utils',
+        'edx-rest-api-client',
     ],
     entry_points={
         'xblock.v1': [

--- a/tests/integration/data/course_api_response.json
+++ b/tests/integration/data/course_api_response.json
@@ -1,0 +1,147 @@
+{
+    "root": "i4x://Org/Course/course/Run",
+    "blocks": {
+        "i4x://Org/Course/vertical/bafcde95db094da586f672794650bfd8": {
+            "display_name": "Unit 4",
+            "block_id": "bafcde95db094da586f672794650bfd8",
+            "student_view_url": "http://example.com/xblock/i4x://Org/Course/vertical/bafcde95db094da586f672794650bfd8",
+            "lms_web_url": "http://example.com/courses/Org/Course/Run/jump_to/i4x://Org/Course/vertical/bafcde95db094da586f672794650bfd8",
+            "type": "vertical",
+            "id": "i4x://Org/Course/vertical/bafcde95db094da586f672794650bfd8"
+        },
+        "i4x://Org/Course/pb-answer/b86edf60454b47dbb8f2e1b4e2d48d6a": {
+            "display_name": "",
+            "block_id": "b86edf60454b47dbb8f2e1b4e2d48d6a",
+            "student_view_url": "http://example.com/xblock/i4x://Org/Course/pb-answer/b86edf60454b47dbb8f2e1b4e2d48d6a",
+            "student_view_data": {
+                "question": "",
+                "name": "23761f7"
+            },
+            "lms_web_url": "http://example.com/courses/Org/Course/Run/jump_to/i4x://Org/Course/pb-answer/b86edf60454b47dbb8f2e1b4e2d48d6a",
+            "type": "pb-answer",
+            "id": "i4x://Org/Course/pb-answer/b86edf60454b47dbb8f2e1b4e2d48d6a"
+        },
+        "i4x://Org/Course/pb-answer/a0b04a13d3074229b6be33fbc31de233": {
+            "display_name": "More Info",
+            "block_id": "a0b04a13d3074229b6be33fbc31de233",
+            "student_view_url": "http://example.com/xblock/i4x://Org/Course/pb-answer/a0b04a13d3074229b6be33fbc31de233",
+            "student_view_data": {
+                "question": "Tell us more about yourself.",
+                "name": "efac891"
+            },
+            "lms_web_url": "http://example.com/courses/Org/Course/Run/jump_to/i4x://Org/Course/pb-answer/a0b04a13d3074229b6be33fbc31de233",
+            "type": "pb-answer",
+            "id": "i4x://Org/Course/pb-answer/a0b04a13d3074229b6be33fbc31de233"
+        },
+        "i4x://Org/Course/sequential/d57c4812c7ac48f1b799e7e19422eff9": {
+            "display_name": "Subsection 1",
+            "block_id": "d57c4812c7ac48f1b799e7e19422eff9",
+            "children": [
+                "i4x://Org/Course/vertical/e428dc5a13ce431583df0cefc4addd7c",
+                "i4x://Org/Course/vertical/6d845e8f56a04bde88f11aec6c885bbe",
+                "i4x://Org/Course/vertical/e87577535d0e4c68a2ac9d760d003c92",
+                "i4x://Org/Course/vertical/bafcde95db094da586f672794650bfd8"
+            ],
+            "student_view_url": "http://example.com/xblock/i4x://Org/Course/sequential/d57c4812c7ac48f1b799e7e19422eff9",
+            "lms_web_url": "http://example.com/courses/Org/Course/Run/jump_to/i4x://Org/Course/sequential/d57c4812c7ac48f1b799e7e19422eff9",
+            "type": "sequential",
+            "id": "i4x://Org/Course/sequential/d57c4812c7ac48f1b799e7e19422eff9"
+        },
+        "i4x://Org/Course/course/Run": {
+            "display_name": "Test Course",
+            "block_id": "Run",
+            "children": [
+                "i4x://Org/Course/chapter/e31d7ee0bf5a4cc2ad38fab460589c90",
+                "i4x://Org/Course/chapter/c154bd7716654193969e20d6e2fd994a"
+            ],
+            "student_view_url": "http://example.com/xblock/i4x://Org/Course/course/Run",
+            "lms_web_url": "http://example.com/courses/Org/Course/Run/jump_to/i4x://Org/Course/course/Run",
+            "type": "course",
+            "id": "i4x://Org/Course/course/Run"
+        },
+        "i4x://Org/Course/chapter/e31d7ee0bf5a4cc2ad38fab460589c90": {
+            "display_name": "First Section",
+            "block_id": "e31d7ee0bf5a4cc2ad38fab460589c90",
+            "children": [
+                "i4x://Org/Course/sequential/d57c4812c7ac48f1b799e7e19422eff9"
+            ],
+            "student_view_url": "http://example.com/xblock/i4x://Org/Course/chapter/e31d7ee0bf5a4cc2ad38fab460589c90",
+            "lms_web_url": "http://example.com/courses/Org/Course/Run/jump_to/i4x://Org/Course/chapter/e31d7ee0bf5a4cc2ad38fab460589c90",
+            "type": "chapter",
+            "id": "i4x://Org/Course/chapter/e31d7ee0bf5a4cc2ad38fab460589c90"
+        },
+        "i4x://Org/Course/vertical/e428dc5a13ce431583df0cefc4addd7c": {
+            "display_name": "Unit 1",
+            "block_id": "e428dc5a13ce431583df0cefc4addd7c",
+            "student_view_url": "http://example.com/xblock/i4x://Org/Course/vertical/e428dc5a13ce431583df0cefc4addd7c",
+            "lms_web_url": "http://example.com/courses/Org/Course/Run/jump_to/i4x://Org/Course/vertical/e428dc5a13ce431583df0cefc4addd7c",
+            "type": "vertical",
+            "id": "i4x://Org/Course/vertical/e428dc5a13ce431583df0cefc4addd7c"
+        },
+        "i4x://Org/Course/vertical/6d845e8f56a04bde88f11aec6c885bbe": {
+            "display_name": "Unit 2",
+            "block_id": "6d845e8f56a04bde88f11aec6c885bbe",
+            "student_view_url": "http://example.com/xblock/i4x://Org/Course/vertical/6d845e8f56a04bde88f11aec6c885bbe",
+            "lms_web_url": "http://example.com/courses/Org/Course/Run/jump_to/i4x://Org/Course/vertical/6d845e8f56a04bde88f11aec6c885bbe",
+            "type": "vertical",
+            "id": "i4x://Org/Course/vertical/6d845e8f56a04bde88f11aec6c885bbe"
+        },
+        "i4x://Org/Course/vertical/e87577535d0e4c68a2ac9d760d003c92": {
+            "display_name": "Unit 3",
+            "block_id": "e87577535d0e4c68a2ac9d760d003c92",
+            "children": [
+                "i4x://Org/Course/pb-answer/b86edf60454b47dbb8f2e1b4e2d48d6a"
+            ],
+            "student_view_url": "http://example.com/xblock/i4x://Org/Course/vertical/e87577535d0e4c68a2ac9d760d003c92",
+            "lms_web_url": "http://example.com/courses/Org/Course/Run/jump_to/i4x://Org/Course/vertical/e87577535d0e4c68a2ac9d760d003c92",
+            "type": "vertical",
+            "id": "i4x://Org/Course/vertical/e87577535d0e4c68a2ac9d760d003c92"
+        },
+        "i4x://Org/Course/chapter/c154bd7716654193969e20d6e2fd994a": {
+            "display_name": "Second Section",
+            "block_id": "c154bd7716654193969e20d6e2fd994a",
+            "children": [
+                "i4x://Org/Course/sequential/4309902bea4d4228ba1895df438c27dc"
+            ],
+            "student_view_url": "http://example.com/xblock/i4x://Org/Course/chapter/c154bd7716654193969e20d6e2fd994a",
+            "lms_web_url": "http://example.com/courses/Org/Course/Run/jump_to/i4x://Org/Course/chapter/c154bd7716654193969e20d6e2fd994a",
+            "type": "chapter",
+            "id": "i4x://Org/Course/chapter/c154bd7716654193969e20d6e2fd994a"
+        },
+        "i4x://Org/Course/pb-answer/6f070c350e39429cbccfd3185a33621c": {
+            "display_name": "Introductions",
+            "block_id": "6f070c350e39429cbccfd3185a33621c",
+            "student_view_url": "http://example.com/xblock/i4x://Org/Course/pb-answer/6f070c350e39429cbccfd3185a33621c",
+            "student_view_data": {
+                "question": "Hello, who are you?",
+                "name": "bf9c37a"
+            },
+            "lms_web_url": "http://example.com/courses/Org/Course/Run/jump_to/i4x://Org/Course/pb-answer/6f070c350e39429cbccfd3185a33621c",
+            "type": "pb-answer",
+            "id": "i4x://Org/Course/pb-answer/6f070c350e39429cbccfd3185a33621c"
+        },
+        "i4x://Org/Course/vertical/8f995fb218664104bb3f898f10744511": {
+            "display_name": "Unit 1",
+            "block_id": "8f995fb218664104bb3f898f10744511",
+            "children": [
+                "i4x://Org/Course/pb-answer/6f070c350e39429cbccfd3185a33621c",
+                "i4x://Org/Course/pb-answer/a0b04a13d3074229b6be33fbc31de233"
+            ],
+            "student_view_url": "http://example.com/xblock/i4x://Org/Course/vertical/8f995fb218664104bb3f898f10744511",
+            "lms_web_url": "http://example.com/courses/Org/Course/Run/jump_to/i4x://Org/Course/vertical/8f995fb218664104bb3f898f10744511",
+            "type": "vertical",
+            "id": "i4x://Org/Course/vertical/8f995fb218664104bb3f898f10744511"
+        },
+        "i4x://Org/Course/sequential/4309902bea4d4228ba1895df438c27dc": {
+            "display_name": "Subsection 2",
+            "block_id": "4309902bea4d4228ba1895df438c27dc",
+            "children": [
+                "i4x://Org/Course/vertical/8f995fb218664104bb3f898f10744511"
+            ],
+            "student_view_url": "http://example.com/xblock/i4x://Org/Course/sequential/4309902bea4d4228ba1895df438c27dc",
+            "lms_web_url": "http://example.com/courses/Org/Course/Run/jump_to/i4x://Org/Course/sequential/4309902bea4d4228ba1895df438c27dc",
+            "type": "sequential",
+            "id": "i4x://Org/Course/sequential/4309902bea4d4228ba1895df438c27dc"
+        }
+    }
+}

--- a/tests/integration/test_eoc_journal.py
+++ b/tests/integration/test_eoc_journal.py
@@ -2,27 +2,129 @@
 Basic integration tests for the EOC Journal XBlock.
 """
 
+import json
+from mock import Mock, patch
+
+from xblock.reference.user_service import XBlockUser
 from xblockutils.studio_editable_test import StudioEditableBaseTest
+from xblockutils.resources import ResourceLoader
+
+
+loader = ResourceLoader(__name__)
+
+
+default_pb_answer_block_ids = [
+    'i4x://Org/Course/pb-answer/b86edf60454b47dbb8f2e1b4e2d48d6a',
+    'i4x://Org/Course/pb-answer/6f070c350e39429cbccfd3185a33621c',
+    'i4x://Org/Course/pb-answer/a0b04a13d3074229b6be33fbc31de233',
+]
+
+def checkbox_value(block_id):
+    """
+    Checkbox value attributes are wrapped in double quotes.
+    This method wraps a block_id (string) into double quotes,
+    which is useful in tests to find checkboxes by block id
+    and comparing checkbox values to expected block ids.
+    """
+    return '"{}"'.format(block_id)
+
 
 class TestEOCJournal(StudioEditableBaseTest):
-
     default_css_selector = 'div.oec-journal-block'
     module_name = __name__
 
 
-    def configure_block(self, key_takeaways_pdf=None):
+    def setUp(self):
+        super(TestEOCJournal, self).setUp()
+        # Patch _get_current_user method.
+        mock_user = Mock()
+        mock_user.username = 'some-user'
+        self.patch('eoc_journal.eoc_journal.EOCJournalXBlock._get_current_user', mock_user)
+        # Patch CourseBlocksApiClient.
+        self.patch('eoc_journal.eoc_journal.CourseBlocksApiClient.connect', Mock())
+        def mock_get_blocks(self, **kwargs):
+            return json.loads(loader.load_unicode('data/course_api_response.json'))
+        self.patch('eoc_journal.eoc_journal.CourseBlocksApiClient.get_blocks', mock_get_blocks)
+
+    def patch(self, item, return_value):
+        patcher = patch(item, return_value)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def set_standard_scenario(self):
         scenario = '<eoc-journal url_name="defaults" />'
         self.set_scenario_xml(scenario)
 
+    def get_element_for_pb_answers_field(self):
+        field = self.browser.find_element_by_css_selector(
+            'li.field[data-field-name=selected_pb_answer_blocks]'
+        )
+        return field
+
+    def configure_block(self, key_takeaways_pdf=None, selected_pb_answer_blocks=[]):
+        self.set_standard_scenario()
         self.go_to_view('studio_view')
         self.fix_js_environment()
+
         if key_takeaways_pdf is not None:
             control = self.get_element_for_field('key_takeaways_pdf')
             control.clear()
             control.send_keys(key_takeaways_pdf)
+        if selected_pb_answer_blocks:
+            field = self.get_element_for_pb_answers_field()
+            for block_id in selected_pb_answer_blocks:
+                selector = "input[type=checkbox][value='{}']".format(checkbox_value(block_id))
+                control = field.find_element_by_css_selector(selector)
+                control.click()
         self.click_save()
 
         self.element = self.go_to_view('student_view')
+
+    def test_pb_answer_blocks_listed_in_edit_view(self):
+        self.set_standard_scenario()
+        self.go_to_view('studio_view')
+        self.fix_js_environment()
+
+        field_control = self.get_element_for_pb_answers_field()
+        items = field_control.find_elements_by_css_selector('.list-settings-item')
+        # There are three pb-answer blocks in the mocked course blocks API response.
+        self.assertEqual(len(items), 3)
+        expected_choices = [
+            {
+                'value': default_pb_answer_block_ids[0],
+                'title': 'First Section / Subsection 1 / Unit 3 / 23761f7',
+            },
+            {
+                'value': default_pb_answer_block_ids[1],
+                'title': 'Second Section / Subsection 2 / Unit 1 / Introductions'
+            },
+            {
+                'value': default_pb_answer_block_ids[2],
+                'title': 'Second Section / Subsection 2 / Unit 1 / More Info'
+            },
+        ]
+        for idx, item in enumerate(items):
+            value = expected_choices[idx]['value']
+            title = expected_choices[idx]['title']
+            checkbox = item.find_element_by_css_selector('input[type=checkbox]')
+            self.assertEqual(checkbox.get_attribute('value'), checkbox_value(value))
+            label = item.find_element_by_css_selector('label')
+            self.assertEqual(label.text, title)
+
+    def test_pb_answer_blocks_selection_preserved_in_edit_view(self):
+        selected_block_id = default_pb_answer_block_ids[1]
+        self.configure_block(selected_pb_answer_blocks=[selected_block_id])
+        # Reload edit view.
+        self.go_to_view('studio_view')
+        field_control = self.get_element_for_pb_answers_field()
+        checked_checkboxes = field_control.find_elements_by_css_selector(
+            'input[type=checkbox]:checked'
+        )
+        self.assertEqual(len(checked_checkboxes), 1)
+        self.assertEqual(
+            checked_checkboxes[0].get_attribute('value'),
+            checkbox_value(selected_block_id)
+        )
 
     def test_no_takeaways_pdf_configured(self):
         self.configure_block()


### PR DESCRIPTION
We are using the edX Course Blocks API to fetch all `pb-answer` blocks in the current course. All `pb-answer` blocks in the course are displayed as labeled checkboxes in the studio edit view. The checkboxes are arranged by section/subsection/unit in the order as they appear in the course.

**Testing**:

1. Add some `pb-answer`(Freeform problem builder questions, also known as Long Answers) blocks to your course. Add them to different sections/units.
1. Add an EOC Journal block to your course.
1. Edit the EOC Journal block in the Studio.
1. Verify that the edit view contains the "Problem Builder Freeform Answers" field, which presents the `pb-answer` blocks from the current course in a checkbox view, allowing you to tick the blocks that you want to select.
1. Tick some checkboxes & save the block.
1. Refresh the page and edit the component again. Verify that block selection is preserved.

**Author Notes**:

1. It looks like the Course Blocks API only returns published modules. You need to publish units that contain freeform problem builder questions before you see them in the edit view of the EOC Journal block. If that is a problem we could investigate adding support to display unpublished modules to Course Blocks API.
1. Checkboxes don't look great in the edit view (padding and vertical alignment are off), but that should be fixed in xblock-utils and is out of scope of this task.

**Reviewers**:

- [x] @bdero 