### PR TITLE
Display selected pb-answers in student view

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,11 @@ Inside a fresh virtualenv, `cd` into the root folder of this repository (`xblock
 ```bash
 $ pip install -U pip wheel
 $ pip install -r requirements-test.txt
+$ pip install -r $VENV/src/xblock-sdk/requirements/base.txt
+$ pip install -r $VENV/src/xblock-sdk/requirements/test.txt
 ```
+
+`$VENV` is your fresh virtual environment root directory.
 
 You can then run the entire test suite via
 

--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,8 @@ dependencies:
   override:
     - "pip install -U pip wheel"
     - "pip install -r requirements-test.txt"
+    - "pip install -r $VIRTUAL_ENV/src/xblock-sdk/requirements/base.txt"
+    - "pip install -r $VIRTUAL_ENV/src/xblock-sdk/requirements/test.txt"
     - "mkdir var"
 test:
   override:

--- a/eoc_journal/course_blocks_api.py
+++ b/eoc_journal/course_blocks_api.py
@@ -6,9 +6,9 @@ from django.conf import settings
 from edx_rest_api_client.client import EdxRestApiClient
 
 try:
-    from openedx.core.lib.token_utils import JwtBuilder
+    from openedx.core.lib.token_utils import JwtBuilder  # pylint: disable=F0401
 except ImportError:
-    JwtBuilder = None
+    JwtBuilder = None  # pylint: disable=C0103
 
 
 class CourseBlocksApiClient(object):

--- a/eoc_journal/templates/eoc_journal.html
+++ b/eoc_journal/templates/eoc_journal.html
@@ -4,6 +4,22 @@
     <h3>{{ display_name }}</h3>
   </div>
 
+  {% if answer_sections %}
+  <div class="eoc-selected-answers">
+    {% for section in answer_sections %}
+      <section class="eoc-selected-answers-section">
+        <h2>{{ section.name }}</h2>
+        {% for q in section.questions %}
+          <div class="eoc-selected-answer">
+            <h3>{{ q.question }}</h3>
+            <p>{{ q.answer }}</p>
+          </div>
+        {% endfor %}
+      </section>
+      {% endfor %}
+  </div>
+  {% endif %}
+
   <p>
     {% if key_takeaways_pdf_url %}
     <a class="key-takeaways-link" target="_blank" href="{{ key_takeaways_pdf_url }}">

--- a/eoc_journal/utils.py
+++ b/eoc_journal/utils.py
@@ -1,6 +1,18 @@
 """EOC Journal XBlock - Utils"""
 
 
+def normalize_id(key):
+    """
+    Helper method to normalize a key to avoid issues where some keys have version/branch and others don't.
+    e.g. self.scope_ids.usage_id != self.runtime.get_block(self.scope_ids.usage_id).scope_ids.usage_id
+    """
+    if hasattr(key, "for_branch"):
+        key = key.for_branch(None)
+    if hasattr(key, "for_version"):
+        key = key.for_version(None)
+    return key
+
+
 def _(text):
     """
     Dummy `gettext` replacement to make string extraction tools scrape strings marked for translation.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 git+https://github.com/edx/xblock-utils.git@v1.0.2#egg=xblock-utils==1.0.2
+git+https://github.com/open-craft/problem-builder@27e2f4ba5afdefcb6a4e5fd793969e1e626a0abe#egg=xblock-problem-builder
 edx-rest-api-client==1.6.0
 -e .

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         'XBlock',
         'xblock-utils',
         'edx-rest-api-client',
+        'xblock-problem-builder',
     ],
     entry_points={
         'xblock.v1': [


### PR DESCRIPTION
**Testing instructions**
- Setup a course with pb-answers and eoc-journal
- Mark at least one pb-answer in eoc-journal when running Studio
- Log into Apros, answer the pb-answer created and go to the roc-journal
- Check that you see the selected pb-answer, with the name of the section it belongs to, it's `display_name` and the `student_input`.

The journal should look like the screenshot below.
<img width="829" alt="screen shot 2017-07-02 at 18 11 16" src="https://user-images.githubusercontent.com/831084/27773535-2ac36102-5f52-11e7-878d-ca6b52ff7fec.png">

To run the integration tests, follow the updated instructions in the README (this PR).
Make sure all tests pass.

**Reviewers**
- [ ] @mtyaka 