### PR TITLE
Show title (display_name) in the LMS.

### DIFF
--- a/eoc_journal/eoc_journal.py
+++ b/eoc_journal/eoc_journal.py
@@ -84,6 +84,8 @@ class EOCJournalXBlock(StudioEditableXBlockMixin, XBlock):
         """
         context = context.copy() if context else {}
 
+        context['display_name'] = self.display_name
+
         key_takeaways_handle = self.key_takeaways_pdf.strip()
         if key_takeaways_handle:
             context["key_takeaways_pdf_url"] = self._expand_static_url(self.key_takeaways_pdf)

--- a/eoc_journal/public/css/eoc_journal.css
+++ b/eoc_journal/public/css/eoc_journal.css
@@ -1,3 +1,7 @@
+.eoc-journal-block .title {
+    margin-bottom: 0.5em;
+}
+
 .eoc-journal-block .key-takeaways-link .fa {
     padding-right: 3px;
 }

--- a/eoc_journal/templates/eoc_journal.html
+++ b/eoc_journal/templates/eoc_journal.html
@@ -1,5 +1,9 @@
 {% load i18n %}
 <div class="eoc-journal-block">
+  <div class="title">
+    <h3>{{ display_name }}</h3>
+  </div>
+
   <p>
     {% if key_takeaways_pdf_url %}
     <a class="key-takeaways-link" target="_blank" href="{{ key_takeaways_pdf_url }}">

--- a/tests/integration/test_eoc_journal.py
+++ b/tests/integration/test_eoc_journal.py
@@ -61,11 +61,15 @@ class TestEOCJournal(StudioEditableBaseTest):
         )
         return field
 
-    def configure_block(self, key_takeaways_pdf=None, selected_pb_answer_blocks=[]):
+    def configure_block(self, display_name=None, key_takeaways_pdf=None, selected_pb_answer_blocks=[]):
         self.set_standard_scenario()
         self.go_to_view('studio_view')
         self.fix_js_environment()
 
+        if display_name is not None:
+            control = self.get_element_for_field('display_name')
+            control.clear()
+            control.send_keys(display_name)
         if key_takeaways_pdf is not None:
             control = self.get_element_for_field('key_takeaways_pdf')
             control.clear()
@@ -126,14 +130,25 @@ class TestEOCJournal(StudioEditableBaseTest):
             checkbox_value(selected_block_id)
         )
 
+    def test_display_name(self):
+        self.configure_block()
+        title = self.element.find_element_by_css_selector('.title h3')
+        # The default title is 'End of Course Journal'.
+        default_title = 'End of Course Journal'
+        self.assertEqual(title.text, default_title)
+        custom_title = 'My Custom Yournal'
+        self.configure_block(display_name=custom_title)
+        title = self.element.find_element_by_css_selector('.title h3')
+        self.assertEqual(title.text, custom_title)
+
     def test_no_takeaways_pdf_configured(self):
         self.configure_block()
         links = self.element.find_elements_by_css_selector('a.key-takeaways-link')
         self.assertEqual(len(links), 0)
-        self.assertIn(self.element.text, 'Key Takeaways PDF not available at this time.')
+        self.assertIn('Key Takeaways PDF not available at this time.', self.element.text)
 
     def test_takeaways_pdf_configured(self):
         self.configure_block(key_takeaways_pdf='/static/my.pdf')
         link = self.element.find_element_by_css_selector('a.key-takeaways-link')
-        self.assertIn(link.text, 'Key Takeaways')
+        self.assertIn('Key Takeaways', link.text)
         self.assertEqual(link.get_attribute('target'), '_blank')


### PR DESCRIPTION
This PR displays the value of `display_name` on the frontend. The `display_name` setting was already configurable in the Studio, but was not displayed on the frontend.

![screen shot 2017-07-04 at 09 54 36](https://user-images.githubusercontent.com/32585/27820440-eb937316-609e-11e7-9f5e-970515d05a67.png)

**Testing**:

1. Add a new EOC Journal block to your course.
1. Verify that the default "End Of Course Journal" title is visible in the LMS.
1. Change the title/display_name in the Studio, save & publish.
1. Observe that the modified title is now visible in the LMS.

**Reviewers**:

- [x] @bdero 