### PR TITLE
Fix progress metrics.

### DIFF
--- a/eoc_journal/api_client.py
+++ b/eoc_journal/api_client.py
@@ -177,6 +177,22 @@ class ApiClient(object):
 
         return get(url, params=params)
 
+    def _get_completion_leader_metrics(self):
+        """
+        Fetches and returns user completion metrics.
+        """
+        params = {
+            'skipleaders': True,
+            'user_id': self.user.id,
+        }
+
+        url = '{base_url}/courses/{course_id}/metrics/completions/leaders/'.format(
+            base_url=self.API_BASE_URL,
+            course_id=self.course_id,
+        )
+
+        return get(url, params=params)
+
     def get_user_progress(self):
         """
         Calculates the progress percentage for the current user.
@@ -216,18 +232,8 @@ class ApiClient(object):
         """
         Fetches and returns cohort average progress.
         """
-        params = {
-            'skipleaders': True,
-            'user_id': self.user.id,
-        }
-
-        url = '{base_url}/courses/{course_id}/metrics/completions/leaders/'.format(
-            base_url=self.API_BASE_URL,
-            course_id=self.course_id,
-        )
-
-        data = get(url, params=params)
+        data = self._get_completion_leader_metrics()
 
         if data:
-            return data.get('cohort_avg', None)
+            return data.get('course_avg', None)
         return None

--- a/eoc_journal/eoc_journal.py
+++ b/eoc_journal/eoc_journal.py
@@ -220,8 +220,8 @@ class EOCJournalXBlock(StudioEditableXBlockMixin, XBlock):
             return None
 
         return {
-            'user': round(user_progress),
-            'cohort_average': round(cohort_average),
+            'user': int(round(user_progress)),
+            'cohort_average': int(round(cohort_average)),
         }
 
     def get_engagement_metrics(self):
@@ -253,8 +253,8 @@ class EOCJournalXBlock(StudioEditableXBlockMixin, XBlock):
                 cohort_score = 0
 
             return {
-                'user_score': round(calculate_engagement_score(user_engagement)),
-                'cohort_score': round(cohort_score),
+                'user_score': int(round(calculate_engagement_score(user_engagement))),
+                'cohort_score': int(round(cohort_score)),
                 'new_posts': user_engagement.get('num_threads', 0),
                 'replies': user_engagement.get('num_replies', 0),
                 'upvotes': user_engagement.get('num_upvotes', 0),

--- a/eoc_journal/templates/eoc_journal.html
+++ b/eoc_journal/templates/eoc_journal.html
@@ -103,6 +103,10 @@
 </div>
 {% endif %}
 
+<div class="eoc-key-takeaways">
+  <div class="title">
+    <h4>Key Takeaways</h4>
+  </div>
 {% if key_takeaways_pdf_url %}
 <p>
 <a class="key-takeaways-link" target="_blank" href="{{ key_takeaways_pdf_url }}">
@@ -113,4 +117,5 @@
 {% else %}
 <p>{% trans "Key Takeaways PDF not available at this time." %}</p>
 {% endif %}
+</div>
 </div>

--- a/tests/integration/test_eoc_journal.py
+++ b/tests/integration/test_eoc_journal.py
@@ -74,9 +74,15 @@ default_engagement_metrics = {
     'posts_followed': 1,
 }
 
+default_completion_leader_metrics = {
+    'position': 1,
+    'course_avg': 17.5,
+    'completions': 33.33,
+}
+
 
 default_user_progress = 4
-default_cohort_average_progress = 30
+default_cohort_average_progress = int(round(default_completion_leader_metrics['course_avg']))
 
 
 class TestEOCJournal(StudioEditableBaseTest):
@@ -103,13 +109,16 @@ class TestEOCJournal(StudioEditableBaseTest):
         )
         # Patch CourseBlocksApiClient.
         self.patch('eoc_journal.eoc_journal.CourseBlocksApiClient.connect', Mock())
+
         def mock_get_blocks(self, **kwargs):
             return json.loads(loader.load_unicode('data/course_api_response.json'))
+
         self.patch('eoc_journal.eoc_journal.CourseBlocksApiClient.get_blocks', mock_get_blocks)
 
         # Patch UserMetricsClient.
         def mock_get_user_engagement_metrics(self):
             return json.loads(loader.load_unicode('data/user_engagement_metrics_response.json'))
+
         self.patch(
             'eoc_journal.api_client.ApiClient.get_user_engagement_metrics',
             mock_get_user_engagement_metrics
@@ -117,6 +126,7 @@ class TestEOCJournal(StudioEditableBaseTest):
 
         def mock_get_cohort_engagement_metrics(self):
             return json.loads(loader.load_unicode('data/cohort_engagement_metrics_response.json'))
+
         self.patch(
             'eoc_journal.api_client.ApiClient.get_cohort_engagement_metrics',
             mock_get_cohort_engagement_metrics
@@ -138,12 +148,12 @@ class TestEOCJournal(StudioEditableBaseTest):
             mock_get_course
         )
 
-        def mock_get_cohort_average_progress(self):
-            return default_cohort_average_progress
+        def mock_get_completion_leader_metrics(self):
+            return default_completion_leader_metrics
 
         self.patch(
-            'eoc_journal.api_client.ApiClient.get_cohort_average_progress',
-            mock_get_cohort_average_progress
+            'eoc_journal.api_client.ApiClient._get_completion_leader_metrics',
+            mock_get_completion_leader_metrics
         )
 
         self.patch(


### PR DESCRIPTION
Progress would not display in the LMS because we were trying to fetch `'cohort_avg'` instead of `'course_avg'` from the API response, so the xblock was always displaying "Progress data is not available." in the LMS.

This also converts some rounded floats to ints to match the format of metrics displayed in apros.

**Testing**:

1. Verify that without this fix the LMS always says "Progress data is not available."
1. Verify that with this fix, the actual progress data is displayed and matches the values on the apros "progress" page.

**Reviewers**:
- [x] @snowcrshd 