### PR TITLE
Adds Proficiency metrics taken from the Gradebook Leaderboard API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@ End of Course Journal XBlock
 ============================
 
 The "End of Course" Journal XBlock provides ability for a participant to download his/her activity once he/she completes
-the course.
+the course.  Currently only [problem-builder](https://github.com/open-craft/problem-builder) freeform answers are supported.
 
-Currently only [problem-builder](https://github.com/open-craft/problem-builder) freeform answers are supported.
+This XBlock also displays a summary of the learner's participation, proficiency, and engagement in the course compared
+with the course averages.
 
 Installation
 ------------

--- a/eoc_journal/api_client.py
+++ b/eoc_journal/api_client.py
@@ -193,6 +193,17 @@ class ApiClient(object):
 
         return get(url, params=params)
 
+    def _get_grades_leader_metrics(self):
+        """
+        Fetches the user grades metrics.
+        """
+        params = {'user_id': self.user.id}
+        url = '{base_url}/courses/{course_id}/metrics/grades/leaders/'.format(
+            base_url=self.API_BASE_URL,
+            course_id=self.course_id,
+        )
+        return get(url, params=params)
+
     def get_user_progress(self):
         """
         Calculates the progress percentage for the current user.
@@ -237,3 +248,20 @@ class ApiClient(object):
         if data:
             return data.get('course_avg', None)
         return None
+
+    def get_user_proficiency(self):
+        """
+        Fetches and returns the user's and average course proficiency scores.
+        """
+        data = self._get_grades_leader_metrics()
+        if data is None:
+            return None
+
+        user_grade = data.get('user_grade')
+        course_avg = data.get('course_avg')
+        if user_grade is None or course_avg is None:
+            return None
+
+        user_grade = int(round(user_grade * 100.0))
+        course_avg = int(round(course_avg * 100.0))
+        return dict(user=user_grade, cohort_average=course_avg)

--- a/eoc_journal/eoc_journal.py
+++ b/eoc_journal/eoc_journal.py
@@ -92,6 +92,7 @@ class EOCJournalXBlock(StudioEditableXBlockMixin, XBlock):
         context["answer_sections"] = self.list_user_pb_answers_by_section()
 
         context["progress"] = self.get_progress_metrics()
+        context["proficiency"] = self.get_proficiency_metrics()
         context["engagement"] = self.get_engagement_metrics()
 
         key_takeaways_handle = self.key_takeaways_pdf.strip()
@@ -222,6 +223,26 @@ class EOCJournalXBlock(StudioEditableXBlockMixin, XBlock):
         return {
             'user': int(round(user_progress)),
             'cohort_average': int(round(cohort_average)),
+        }
+
+    def get_proficiency_metrics(self):
+        """
+        Fetches and returns dict with proficiency (grades) metrics for the current user
+        in the course.
+        """
+        user = self._get_current_user()
+        course_id = self._get_course_id()
+        client = ApiClient(user, course_id)
+
+        proficiency = client.get_user_proficiency()
+
+        if proficiency is None:
+            return None
+
+        return {
+            'user': int(round(proficiency.get('user', 0))),
+            'cohort_average': int(round(proficiency.get('cohort_average', 0))),
+            'graded_items': proficiency.get('graded_items', []),
         }
 
     def get_engagement_metrics(self):

--- a/eoc_journal/templates/eoc_journal.html
+++ b/eoc_journal/templates/eoc_journal.html
@@ -27,6 +27,29 @@
     </div>
   </div>
 
+  <div class="proficiency-metrics">
+    <div class="title">
+      <h4>{% trans "Proficiency" %}</h4>
+      <p>
+
+      {% if proficiency %}
+
+      {% blocktrans with proficiency=proficiency.user tag_start='<span data-proficiency-name="user">' tag_end='</span>' %}
+      Your current proficiency score is {{ tag_start }}{{ proficiency }}{{ tag_end }}% following completion of graded
+      items in this course.
+      {% endblocktrans %}
+
+      {% blocktrans with proficiency=proficiency.cohort_average tag_start='<span data-proficiency-name="cohort">' tag_end='</span>' %}
+      The cohort average is {{ tag_start }}{{ proficiency }}{{ tag_end }}%.
+      {% endblocktrans %}
+
+      {% else %}
+      {% trans "Proficiency data is not available." %}
+      {% endif %}
+      </p>
+    </div>
+  </div>
+
   <div class="engagement-metrics">
     <div class="title">
       <h4>{% trans "Engagement" %}</h4>

--- a/tests/integration/data/grades_leader_metrics_response.json
+++ b/tests/integration/data/grades_leader_metrics_response.json
@@ -1,0 +1,4 @@
+{
+  "course_avg": 0.437,
+  "user_grade": 0.833333
+}


### PR DESCRIPTION
Adds Proficiency metrics to the EOC Journal, as presented by the Gradebook Leaderboard API.

**JIRA tickets**: MCKIN-4999

**Screenshots**:

In Studio:
![screen shot 2017-07-28 at 11 16 30 pm](https://user-images.githubusercontent.com/7556571/28719945-dba0d994-73ea-11e7-822a-ccf70e1c4ada.png)

In Solutions LMS:
![screen shot 2017-07-28 at 11 15 56 pm](https://user-images.githubusercontent.com/7556571/28719950-df783238-73ea-11e7-9857-eb5bdeb3c087.png)

**Partner information**: 3rd party-hosted open edX instance

**Testing instructions**:

*Note*: For best results, register new users to perform each of these steps. The demo users created by the Solutions devstack don't have `UserProfile` entries, and so the EOC Journal XBlock shows errors when these users try to view the units.


In Studio:
1. Create a new course.
1. Under "Advanced Settings", add `"eoc-journal"`.
1. Add a graded Subsection, with one or more problems in it.
1. Add a unit containing an EOC Journal component.
1. Note that the "Proficiency" section shows the following text in Studio:
    ```
    Proficiency data is not available.
    ```

In Solutions LMS:
1. Ensure that `FEATURES['PERSISTENT_GRADES_ENABLED_FOR_ALL_TESTS'] = True`.
1. Visit course, and view the EOC Journal unit. Note the "Proficiency" text:
    ```
    Your current proficiency score is 0% following completion of graded items in this course.
    The cohort average is 0%.
    ```
1. Complete some problems.  Your devstack will log a message like "Updated gradebook for user 15 in course OpenCraft/MCKIN/4999 with grade 0.5", indicating the gradebook has been updated.
1. Re-visit the EOC Journal, and note the "Proficiency" text updates to show the current grade and average course grade.

Non-Solutions LMS:
1. Follow the above instructions for adding the EOC Journal XBlock to a course.
1. Viewing the XBlock in the non-Solutions LMS will always show the "unavailable" text, regardless of problem scores:
    ```
    Proficiency data is not available.
    ```

Automated tests:
1. Follow xblock [Testing](https://github.com/open-craft/xblock-eoc-journal#testing) instructions to run automated tests.

**Reviewers**
- [ ] @bdero 
- [ ] second reviewer TBD