### PR TITLE
Fix incorrect progress/engagement metrics

### DIFF
--- a/eoc_journal/eoc_journal.py
+++ b/eoc_journal/eoc_journal.py
@@ -277,7 +277,7 @@ class EOCJournalXBlock(StudioEditableXBlockMixin, XBlock):
                 'user_score': int(round(calculate_engagement_score(user_engagement))),
                 'cohort_score': int(round(cohort_score)),
                 'new_posts': user_engagement.get('num_threads', 0),
-                'replies': user_engagement.get('num_replies', 0),
+                'total_replies': user_engagement.get('num_replies', 0) + user_engagement.get('num_comments', 0),
                 'upvotes': user_engagement.get('num_upvotes', 0),
                 'comments_generated': user_engagement.get('num_comments_generated', 0),
                 'posts_followed': user_engagement.get('num_thread_followers', 0),

--- a/eoc_journal/templates/eoc_journal.html
+++ b/eoc_journal/templates/eoc_journal.html
@@ -82,7 +82,7 @@
 
           <tr>
             <td>{% trans "Number of Replies you made to other posts" %}</td>
-            <td data-point-name="replies">{{ engagement.replies }}</td>
+            <td data-point-name="total_replies">{{ engagement.total_replies }}</td>
           </tr>
 
           <tr>

--- a/tests/integration/data/user_engagement_metrics_response.json
+++ b/tests/integration/data/user_engagement_metrics_response.json
@@ -2,6 +2,7 @@
   "num_threads": 1,
   "num_upvotes": 1,
   "num_replies": 1,
+  "num_comments": 1,
   "num_comments_generated": 1,
   "num_thread_followers": 1
 }

--- a/tests/integration/test_eoc_journal.py
+++ b/tests/integration/test_eoc_journal.py
@@ -57,6 +57,7 @@ default_answers_data = [
 
 default_social_metrics_points = {
     'num_threads': 1,
+    'num_comments': 1,
     'num_replies': 1,
     'num_upvotes': 1,
     'num_comments_generated': 1,
@@ -65,10 +66,10 @@ default_social_metrics_points = {
 
 
 default_engagement_metrics = {
-    'user_score': 5,
+    'user_score': 6,
     'cohort_score': 9,
     'new_posts': 1,
-    'replies': 1,
+    'total_replies': 2,
     'upvotes': 1,
     'comments_generated': 1,
     'posts_followed': 1,


### PR DESCRIPTION
Incorrect Engagement Metrics

When "Number of Replies you made to other posts" is reported to the user, in the Apros LMS, it's reporting

```python
"total_replies": social["metrics"].num_replies + social["metrics"].num_comments,
```

But in this XBlock, only `num_replies` were being included, resulting in discrepancies between this XBlock and the progress page if the user had commented on other posts.

Testing instructions:

Have/import a course with this XBlock and some discussion forums. Enroll two users in that course. Make some forum posts as one or both of the users, including replies and comments on those replies. Verify that the progress page in apros and this EOC Journal XBlock show the same breakdown of engagement scores.