### PR TITLE
Make _get_course method use JWT authentication.

### DIFF
--- a/eoc_journal/utils.py
+++ b/eoc_journal/utils.py
@@ -1,5 +1,12 @@
 """EOC Journal XBlock - Utils"""
 
+from edx_rest_api_client.client import EdxRestApiClient
+
+try:
+    from openedx.core.lib.token_utils import JwtBuilder  # pylint: disable=F0401
+except ImportError:
+    JwtBuilder = None  # pylint: disable=C0103
+
 
 def normalize_id(key):
     """
@@ -18,3 +25,20 @@ def _(text):
     Dummy `gettext` replacement to make string extraction tools scrape strings marked for translation.
     """
     return text
+
+
+def build_jwt_edx_client(url, scopes, user, expires_in, append_slash=True):
+    """
+    Returns an edx API client authorized using JWT.
+    """
+    if JwtBuilder is None:
+        raise NotConnectedToOpenEdX("This package must be installed in an OpenEdX environment.")
+    jwt = JwtBuilder(user).build_token(scopes, expires_in)
+    return EdxRestApiClient(url, append_slash=append_slash, jwt=jwt)
+
+
+class NotConnectedToOpenEdX(Exception):
+    """
+    Exception to raise when not connected to OpenEdX.
+    """
+    pass

--- a/tests/integration/test_eoc_journal.py
+++ b/tests/integration/test_eoc_journal.py
@@ -120,6 +120,8 @@ class TestEOCJournal(StudioEditableBaseTest):
         self.patch('eoc_journal.eoc_journal.CourseBlocksApiClient.get_blocks', mock_get_blocks)
 
         # Patch UserMetricsClient.
+        self.patch('eoc_journal.api_client.ApiClient.connect_with_jwt', Mock())
+    
         def mock_get_user_engagement_metrics(self):
             return json.loads(loader.load_unicode('data/user_engagement_metrics_response.json'))
 


### PR DESCRIPTION
This PR makes `_get_course method` use JWT authentication as it is required now since https://github.com/edx-solutions/api-integration/pull/102 is merged (and, thus, [CourseDetail](https://github.com/edx-solutions/api-integration/blob/master/edx_solutions_api_integration/courses/views.py#L564) inherits from [MobileAPIView](MobileAPIView)).

**Dependencies**: None

**Screenshots**: n/a

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: None

**Testing instructions**:

1. Run the course with an End of Course Journal Xblock.
2. See it fail on the current master (observe `401` error in the backend console for a GET call to `/api/server/courses/{course_id}?depth=5`).
3. Make devstack use this PR's branch of xblock-eoc-journal.
4. Go again to an End of Course Journal Xblock and see it rendered correctly.


**Reviewers**
- [ ] @jcdyer

Signed-off-by: Tomasz Gargas <tomasz@opencraft.com>