### PR TITLE
Migrate to CircleCI v2 

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,15 +1,30 @@
-machine:
-  python:
-    version: 2.7.10
-dependencies:
-  override:
-    - "pip install -U pip wheel"
-    - "pip install -r requirements-test.txt"
-    - "pip install -r $VIRTUAL_ENV/src/xblock-sdk/requirements/base.txt"
-    - "pip install -r $VIRTUAL_ENV/src/xblock-sdk/requirements/test.txt"
-    - "mkdir var"
-test:
-  override:
-    - "pep8 eoc_journal --max-line-length=120"
-    - "pylint eoc_journal"
-    - "python run_tests.py"
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/python:2.7.14-browsers
+    steps:
+      - checkout
+      - restore_cache:
+          key: dependencies-{{ checksum "circle.yml" }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-test.txt" }}
+      - run:
+          name: Install Python deps in a venv
+          command: |
+            virtualenv venv
+            . venv/bin/activate
+            pip install -U pip wheel
+            pip install -r requirements-test.txt
+            pip install -r venv/src/xblock-sdk/requirements/base.txt
+            pip install -r venv/src/xblock-sdk/requirements/test.txt
+            mkdir var
+      - save_cache:
+          key: dependencies-{{ checksum "circle.yml" }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-test.txt" }}
+          paths:
+            - "venv"
+      - run:
+          name: Run tests
+          command: |
+            . venv/bin/activate
+            pep8 eoc_journal --max-line-length=120
+            pylint eoc_journal
+            python run_tests.py


### PR DESCRIPTION
Migrating to CircleCI version 2.

JIRA Ticket: OC-4151

Testing instructions:

Check that tests are passing.

Note to reviewer:

Added Cache, so that it doesn't have to install requirements each time.