### PR TITLE
[MCKIN-7700] Strip HTML tags from questions when displaying them in EOC Journal

### DIFF
--- a/eoc_journal/eoc_journal.py
+++ b/eoc_journal/eoc_journal.py
@@ -6,6 +6,9 @@ from collections import OrderedDict
 from io import BytesIO
 import webob
 
+from lxml import html
+from lxml.html.clean import clean_html
+
 from reportlab.lib import pagesizes
 from reportlab.lib.styles import getSampleStyleSheet
 from reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer
@@ -178,9 +181,12 @@ class EOCJournalXBlock(StudioEditableXBlockMixin, XBlock):
                 if section not in answers:
                     answers[section] = []
 
+                parsed_question = html.fromstring(block['question'])
+                question = clean_html(parsed_question).text_content()
+
                 answers[section].append({
                     'answer': students_inputs.get(name, _('Not answered yet.')),
-                    'question': block['question'],
+                    'question': question,
                 })
 
             # Make list of sections-answers

--- a/eoc_journal/public/css/eoc_journal.css
+++ b/eoc_journal/public/css/eoc_journal.css
@@ -5,3 +5,11 @@
 .eoc-journal-block .key-takeaways-link .fa {
     padding-right: 3px;
 }
+
+.eoc-journal-block .eoc-selected-answers h4 {
+    margin-bottom: 0.5em;
+}
+
+.eoc-journal-block .eoc-selected-answers h5 {
+    margin-bottom: 0.33em;
+}

--- a/eoc_journal/templates/eoc_journal.html
+++ b/eoc_journal/templates/eoc_journal.html
@@ -108,49 +108,48 @@
     </div>
 
   </div>
-</div>
 
-{% if answer_sections %}
-<div class="eoc-selected-answers">
-  {% for section in answer_sections %}
-  <section class="eoc-selected-answers-section">
-    <h4>{{ section.name }}</h4>
-    {% for q in section.questions %}
-    <div class="eoc-selected-answer">
-      <h5>{{ q.question }}</h5>
-      <p>{{ q.answer }}</p>
-    </div>
+  {% if answer_sections %}
+  <div class="eoc-selected-answers">
+    {% for section in answer_sections %}
+    <section class="eoc-selected-answers-section">
+      <h4>{{ section.name }}</h4>
+      {% for q in section.questions %}
+      <div class="eoc-selected-answer">
+        <h5>{{ q.question }}</h5>
+        <p>{{ q.answer }}</p>
+      </div>
+      {% endfor %}
+    </section>
     {% endfor %}
-  </section>
-  {% endfor %}
-</div>
-
-<div class="eoc-pdf-report">
-  <div class="title">
-    <h4>PDF Report</h4>
   </div>
-  <p>
-    <a class="pdf-report-link" target="_blank" href="{{ pdf_report_url }}">
-      <span class="fa fa-file-text-o" aria-hidden="true"></span>
-      {% trans "Download PDF" %}
-    </a>
-  </p>
-</div>
-{% endif %}
 
-<div class="eoc-key-takeaways">
-  <div class="title">
-    <h4>Key Takeaways</h4>
+  <div class="eoc-pdf-report">
+    <div class="title">
+      <h4>PDF Report</h4>
+    </div>
+    <p>
+      <a class="pdf-report-link" target="_blank" href="{{ pdf_report_url }}">
+        <span class="fa fa-file-text-o" aria-hidden="true"></span>
+        {% trans "Download PDF" %}
+      </a>
+    </p>
   </div>
-{% if key_takeaways_pdf_url %}
-<p>
-<a class="key-takeaways-link" target="_blank" href="{{ key_takeaways_pdf_url }}">
-  <span class="fa fa-file-text-o" aria-hidden="true"></span>
-  {% trans "Key Takeaways" %}
-</a>
-</p>
-{% else %}
-<p>{% trans "Key Takeaways PDF not available at this time." %}</p>
-{% endif %}
-</div>
+  {% endif %}
+
+  <div class="eoc-key-takeaways">
+    <div class="title">
+      <h4>Key Takeaways</h4>
+    </div>
+    {% if key_takeaways_pdf_url %}
+    <p>
+      <a class="key-takeaways-link" target="_blank" href="{{ key_takeaways_pdf_url }}">
+        <span class="fa fa-file-text-o" aria-hidden="true"></span>
+        {% trans "Key Takeaways" %}
+      </a>
+    </p>
+    {% else %}
+    <p>{% trans "Key Takeaways PDF not available at this time." %}</p>
+    {% endif %}
+  </div>
 </div>

--- a/tests/integration/data/course_api_response.json
+++ b/tests/integration/data/course_api_response.json
@@ -26,7 +26,7 @@
             "block_id": "a0b04a13d3074229b6be33fbc31de233",
             "student_view_url": "http://example.com/xblock/i4x://Org/Course/pb-answer/a0b04a13d3074229b6be33fbc31de233",
             "student_view_data": {
-                "question": "Tell us more about yourself.",
+                "question": "<p>Tell us more about <strong>yourself</strong>.</p>",
                 "name": "efac891"
             },
             "lms_web_url": "http://example.com/courses/Org/Course/Run/jump_to/i4x://Org/Course/pb-answer/a0b04a13d3074229b6be33fbc31de233",
@@ -113,7 +113,7 @@
             "block_id": "6f070c350e39429cbccfd3185a33621c",
             "student_view_url": "http://example.com/xblock/i4x://Org/Course/pb-answer/6f070c350e39429cbccfd3185a33621c",
             "student_view_data": {
-                "question": "Hello, who are you?",
+                "question": "Hello, who <em>are</em> you? What&#8217;s your name?",
                 "name": "bf9c37a"
             },
             "lms_web_url": "http://example.com/courses/Org/Course/Run/jump_to/i4x://Org/Course/pb-answer/6f070c350e39429cbccfd3185a33621c",

--- a/tests/integration/test_eoc_journal.py
+++ b/tests/integration/test_eoc_journal.py
@@ -54,12 +54,14 @@ default_pb_answer_block_ids = [
 
 
 default_answers_data = [
-    FakeAnswer("efac891", 'student input', 'Tell us more about yourself.'),
+    FakeAnswer("efac891", 'student input', '<p>Tell us more about <strong>yourself</strong>.</p>'),
 ]
 
+# Note that questions may originally contain HTML tags, but HTML tags should be stripped
+# when listing the questions/answers in the EOC journal.
 expected_answers_data = [
-    {'question': 'Hello, who are you?', 'answer': 'Not answered yet.'},
-    {'question': 'Tell us more about yourself.', 'answer': 'student input'},
+    {'question': u'Hello, who are you? What\u2019s your name?', 'answer': 'Not answered yet.'},
+    {'question': u'Tell us more about yourself.', 'answer': 'student input'},
 ]
 
 

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -20,7 +20,7 @@ def extract_text_from_pdf(pdf_content):
     for page in PDFPage.get_pages(input_buffer):
         interpreter.process_page(page)
 
-    text = output_buffer.getvalue()
+    text = output_buffer.getvalue().decode('utf-8')
 
     device.close()
     input_buffer.close()


### PR DESCRIPTION
This fixes a problem where HTML tags would be displayed in EOC Journal freeform answer summary section.

**Screenshots**:

Before:

<img width="1214" alt="screen shot 2018-06-06 at 09 39 23" src="https://user-images.githubusercontent.com/32585/41024043-602a9938-696e-11e8-9963-e8c0a1fe68d3.png">

After:

<img width="1208" alt="screen shot 2018-06-06 at 09 37 45" src="https://user-images.githubusercontent.com/32585/41024034-5ab668d8-696e-11e8-9110-dff0acbb6433.png">


**Testing Instructions**:

1. Create a course that contains some Problem Builder blocks containing Long Answer question types and an End of Course Journal component. Add some HTML to the `question` field of some Long Answer components. The easiest way to set it up is to use the [apros test course](https://github.com/mckinseyacademy/mcka_apros/tree/development/tests/data/test_course1), then modify some existing Long Answers to include HTML tags.
1. In the EOC Journal Studio edit view, tick the boxes next to the freeform answers that you want to appear in the report, and save.
1. Verify that HTML tags are stripped/not displayed in the freeform answer summary in the EOC Journal component.

**Reviewers**:

- [ ] @xitij2000 
