### PR TITLE
MCKIN-7791 Allow customising PDF report link tile and text

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ the course.  Currently only [problem-builder](https://github.com/open-craft/prob
 This XBlock also displays a summary of the learner's participation, proficiency, and engagement in the course compared
 with the course averages.
 
+NOTE: While it is called the End of Course Journal, the block can actually be added at any point during the course.
+
 Installation
 ------------
 

--- a/eoc_journal/eoc_journal.py
+++ b/eoc_journal/eoc_journal.py
@@ -62,7 +62,7 @@ class EOCJournalXBlock(StudioEditableXBlockMixin, XBlock):
     display_name = String(
         display_name=_("Title (display name)"),
         help=_("Title to display"),
-        default=_("End of Course Journal"),
+        default=_("Course Journal"),
         scope=Scope.content,
     )
 
@@ -85,10 +85,26 @@ class EOCJournalXBlock(StudioEditableXBlockMixin, XBlock):
         list_values_provider=provide_pb_answer_list,
     )
 
+    pdf_report_link_heading = String(
+        display_name=_("PDF Report Link heading"),
+        help=_("The heading text to display above the link for downloading the PDF Report."),
+        default=_("PDF Report"),
+        scope=Scope.content,
+    )
+
+    pdf_report_link_text = String(
+        display_name=_("PDF Report Link text"),
+        help=_("The text to display in the link for downloading the PDF Report."),
+        default=_("Download PDF"),
+        scope=Scope.content,
+    )
+
     editable_fields = (
         'display_name',
         'key_takeaways_pdf',
         'selected_pb_answer_blocks',
+        'pdf_report_link_heading',
+        'pdf_report_link_text',
     )
 
     def student_view(self, context=None):
@@ -109,6 +125,8 @@ class EOCJournalXBlock(StudioEditableXBlockMixin, XBlock):
             context["key_takeaways_pdf_url"] = self._expand_static_url(self.key_takeaways_pdf)
 
         context["pdf_report_url"] = self.runtime.handler_url(self, "serve_pdf")
+        context["pdf_report_link_heading"] = self.pdf_report_link_heading
+        context["pdf_report_link_text"] = self.pdf_report_link_text
 
         fragment = Fragment()
         fragment.add_content(

--- a/eoc_journal/templates/eoc_journal.html
+++ b/eoc_journal/templates/eoc_journal.html
@@ -126,12 +126,12 @@
 
   <div class="eoc-pdf-report">
     <div class="title">
-      <h4>PDF Report</h4>
+      <h4>{{ pdf_report_link_heading }}</h4>
     </div>
     <p>
       <a class="pdf-report-link" target="_blank" href="{{ pdf_report_url }}">
         <span class="fa fa-file-text-o" aria-hidden="true"></span>
-        {% trans "Download PDF" %}
+        {{ pdf_report_link_text }}
       </a>
     </p>
   </div>

--- a/tests/integration/test_eoc_journal.py
+++ b/tests/integration/test_eoc_journal.py
@@ -235,7 +235,12 @@ class TestEOCJournal(StudioEditableBaseTest):
         )
         return element
 
-    def configure_block(self, display_name=None, key_takeaways_pdf=None, selected_pb_answer_blocks=[]):
+    def configure_block(self, 
+                        display_name=None, 
+                        key_takeaways_pdf=None, 
+                        selected_pb_answer_blocks=[], 
+                        pdf_report_link_heading=None, 
+                        pdf_report_link_text=None):
         self.set_standard_scenario()
         self.go_to_view('studio_view')
         self.fix_js_environment()
@@ -254,6 +259,14 @@ class TestEOCJournal(StudioEditableBaseTest):
                 selector = "input[type=checkbox][value='{}']".format(checkbox_value(block_id))
                 control = field.find_element_by_css_selector(selector)
                 control.click()
+        if pdf_report_link_heading is not None:
+            control = self.get_element_for_field('pdf_report_link_heading')
+            control.clear()
+            control.send_keys(pdf_report_link_heading)
+        if pdf_report_link_text is not None:
+            control = self.get_element_for_field('pdf_report_link_text')
+            control.clear()
+            control.send_keys(pdf_report_link_text)
         self.click_save()
 
         self.element = self.go_to_view('student_view')
@@ -440,8 +453,8 @@ class TestEOCJournal(StudioEditableBaseTest):
     def test_display_name(self):
         self.configure_block()
         title = self.element.find_element_by_css_selector('.title h3')
-        # The default title is 'End of Course Journal'.
-        default_title = 'End of Course Journal'
+        # The default title is 'Course Journal'.
+        default_title = 'Course Journal'
         self.assertEqual(title.text, default_title)
         custom_title = 'My Custom Yournal'
         self.configure_block(display_name=custom_title)
@@ -459,3 +472,30 @@ class TestEOCJournal(StudioEditableBaseTest):
         link = self.element.find_element_by_css_selector('a.key-takeaways-link')
         self.assertIn('Key Takeaways', link.text)
         self.assertEqual(link.get_attribute('target'), '_blank')
+
+    def test_no_pdf_report_link_heading_configured(self):
+        selected_block_ids = default_pb_answer_block_ids[1:]
+        self.configure_block(selected_pb_answer_blocks=selected_block_ids)
+        heading = self.element.find_element_by_css_selector('.eoc-pdf-report .title')
+        self.assertEqual('PDF Report', heading.text)
+
+    def test_pdf_report_link_heading_configured(self):
+        selected_block_ids = default_pb_answer_block_ids[1:]
+        self.configure_block(selected_pb_answer_blocks=selected_block_ids, 
+                             pdf_report_link_heading='My Report')
+        heading = self.element.find_element_by_css_selector('.eoc-pdf-report .title')
+        self.assertEqual('My Report', heading.text)
+    
+    def test_no_pdf_report_link_text_configured(self):
+        selected_block_ids = default_pb_answer_block_ids[1:]
+        self.configure_block(selected_pb_answer_blocks=selected_block_ids)
+        link = self.element.find_element_by_css_selector('a.pdf-report-link')
+        self.assertEqual('Download PDF', link.text)
+
+    def test_pdf_report_link_text_configured(self):
+        selected_block_ids = default_pb_answer_block_ids[1:]
+        self.configure_block(selected_pb_answer_blocks=selected_block_ids, 
+                             pdf_report_link_text='Download Report')
+        link = self.element.find_element_by_css_selector('a.pdf-report-link')
+        self.assertEqual('Download Report', link.text)
+


### PR DESCRIPTION
Adds the ability to customise the link text and title for the PDF Report link. 

**Reviewer:**
- [ ] @jcdyer 