### PR TITLE
MCKIN-7788 Adds Google Analytics click handlers to PDF download links

### DIFF
--- a/eoc_journal/eoc_journal.py
+++ b/eoc_journal/eoc_journal.py
@@ -117,6 +117,9 @@ class EOCJournalXBlock(StudioEditableXBlockMixin, XBlock):
         fragment.add_css_url(
             self.runtime.local_resource_url(self, "public/css/eoc_journal.css")
         )
+        fragment.add_javascript_url(
+            self.runtime.local_resource_url(self, "public/js/eoc_journal.js")
+        )
         return fragment
 
     @XBlock.handler

--- a/eoc_journal/eoc_journal.py
+++ b/eoc_journal/eoc_journal.py
@@ -120,6 +120,7 @@ class EOCJournalXBlock(StudioEditableXBlockMixin, XBlock):
         fragment.add_javascript_url(
             self.runtime.local_resource_url(self, "public/js/eoc_journal.js")
         )
+        fragment.initialize_js('EOCJournalXBlock')
         return fragment
 
     @XBlock.handler

--- a/eoc_journal/public/js/eoc_journal.js
+++ b/eoc_journal/public/js/eoc_journal.js
@@ -1,0 +1,14 @@
+/* Javascript loaded in the learner view of the EOC Journal */
+
+$(document).ready(function() {
+    // Attach Google Analytics tracking to a set of events
+    var ga = window[window['GoogleAnalyticsObject'] || 'ga'];
+    if (typeof ga == 'function') {
+        $('a.pdf-report-link').click(function() {
+            ga('send', 'event', 'xblock-eoc-journal', 'click', 'PDF Report Download');
+        });
+        $('a.key-takeaways-link').click(function() {
+            ga('send', 'event', 'xblock-eoc-journal', 'click', 'Key Takeaways PDF Download');
+        });
+    }
+});

--- a/eoc_journal/public/js/eoc_journal.js
+++ b/eoc_journal/public/js/eoc_journal.js
@@ -1,14 +1,14 @@
 /* Javascript loaded in the learner view of the EOC Journal */
 
-$(document).ready(function() {
+function EOCJournalXBlock(runtime, element) {
     // Attach Google Analytics tracking to a set of events
     var ga = window[window['GoogleAnalyticsObject'] || 'ga'];
     if (typeof ga == 'function') {
-        $('a.pdf-report-link').click(function() {
+        $(element).find('a.pdf-report-link').click(function() {
             ga('send', 'event', 'xblock-eoc-journal', 'click', 'PDF Report Download');
         });
-        $('a.key-takeaways-link').click(function() {
+        $(element).find('a.key-takeaways-link').click(function() {
             ga('send', 'event', 'xblock-eoc-journal', 'click', 'Key Takeaways PDF Download');
         });
     }
-});
+}

--- a/eoc_journal/public/js/eoc_journal.js
+++ b/eoc_journal/public/js/eoc_journal.js
@@ -1,14 +1,14 @@
-/* Javascript loaded in the learner view of the EOC Journal */
+/* Javascript loaded in the learner view of the Course Journal */
 
 function EOCJournalXBlock(runtime, element) {
     // Attach Google Analytics tracking to a set of events
     var ga = window[window['GoogleAnalyticsObject'] || 'ga'];
     if (typeof ga == 'function') {
         $(element).find('a.pdf-report-link').click(function() {
-            ga('send', 'event', 'xblock-eoc-journal', 'click', 'PDF Report Download');
+            ga('send', 'event', 'Course Journal', 'click', 'PDF Report Download');
         });
         $(element).find('a.key-takeaways-link').click(function() {
-            ga('send', 'event', 'xblock-eoc-journal', 'click', 'Key Takeaways PDF Download');
+            ga('send', 'event', 'Course Journal', 'click', 'Key Takeaways PDF Download');
         });
     }
 }

--- a/eoc_journal/public/js/eoc_journal.js
+++ b/eoc_journal/public/js/eoc_journal.js
@@ -4,10 +4,10 @@ function EOCJournalXBlock(runtime, element) {
     // Attach Google Analytics tracking to a set of events
     var ga = window[window['GoogleAnalyticsObject'] || 'ga'];
     if (typeof ga == 'function') {
-        $(element).find('a.pdf-report-link').click(function() {
+        $('a.pdf-report-link', element).click(function() {
             ga('send', 'event', 'Course Journal', 'click', 'PDF Report Download');
         });
-        $(element).find('a.key-takeaways-link').click(function() {
+        $('a.key-takeaways-link', element).click(function() {
             ga('send', 'event', 'Course Journal', 'click', 'Key Takeaways PDF Download');
         });
     }


### PR DESCRIPTION
Sends an event to Google Analytics (if configured) when a learner clicks on either the 
"PDF Report" or "Key Takeaways" download links displayed by this xblock.

**Screenshots**
EOC Journal XBlock GUI (unchanged):
![eoc journal](https://user-images.githubusercontent.com/7556571/42016239-ed12c1e0-7ae9-11e8-82a4-bbf2060fea51.png)

Google analytics screen showing events received for these events:
![ga events](https://user-images.githubusercontent.com/7556571/42068181-a594f90a-7b89-11e8-9425-1a2ebcff0677.png)

**Testing instructions**
1. Create a course with a subsection containing a Problem Builder Long answer, and an EOC Journal unit, e.g. [MCKIN-7788.ooVv6d.tar.gz](https://github.com/open-craft/xblock-eoc-journal/files/2147388/MCKIN-7788.ooVv6d.tar.gz)
  Ensure that a Key Takeaways PDF is provided, and/or the EOC unit is linked to the Problem Builder long answer problem.
* View the PB unit in Studio, LMS, or Apros, and complete the long answer problem.
  This allows the EOC XBlock to show the "PDF Report" download link.
* View the EOC unit in Apros without enabling Google Analytics.
   Note that no errors should be seen in the JS console, and the EOC XBlock should continue to function as usual.
* Enable Google Analytics by updating the apros `settings.GA_TRACKING_ID` to a tracking ID (`UA-xxxxxxxxx-x`).
* Reload the EOC unit, and note that an event is sent to Google Analytics when the PDF download links are clicked.
   * *Note*: Don't use a private browsing window to test the GA hit -- browsers like [Firefox provide tracking protection](https://developer.mozilla.org/en-US/Firefox/Privacy/Tracking_Protection?utm_source=mozilla&utm_medium=firefox-console-errors&utm_campaign=default) against domains which track users across sites, and so the GA script won't load.

**Reviewers**
- [ ] @symbolist