### PR TITLE
MCKIN-7789: Add option to hide metrics, key takeaways and free text answers from student view.

### DIFF
--- a/eoc_journal/templates/eoc_journal.html
+++ b/eoc_journal/templates/eoc_journal.html
@@ -4,6 +4,7 @@
     <h3>{{ display_name }}</h3>
   </div>
 
+  {% if display_user_metrics %}
   <div class="progress-metrics">
     <div class="title">
       <h4>{% trans "Progress" %}</h4>
@@ -108,8 +109,11 @@
     </div>
 
   </div>
+  {% endif %}
 
   {% if answer_sections %}
+
+  {% if display_answers %}
   <div class="eoc-selected-answers">
     {% for section in answer_sections %}
     <section class="eoc-selected-answers-section">
@@ -123,6 +127,7 @@
     </section>
     {% endfor %}
   </div>
+  {% endif %}
 
   <div class="eoc-pdf-report">
     <div class="title">
@@ -137,6 +142,7 @@
   </div>
   {% endif %}
 
+  {% if display_keytakeaways %}
   <div class="eoc-key-takeaways">
     <div class="title">
       <h4>Key Takeaways</h4>
@@ -152,4 +158,5 @@
     <p>{% trans "Key Takeaways PDF not available at this time." %}</p>
     {% endif %}
   </div>
+  {% endif %}
 </div>


### PR DESCRIPTION
Add options in Edit view in studio to hide metrics, key takeaways and free text answers from student view.

**Testing instructions**
1. Create a course with a subsection containing a Problem Builder Long answer, and an EOC Journal unit.

2. Check that by default only _PDF Report Download_ section is visible.
3. Set newly-added options in Studio, namely:
- `Display User Metrics`
- `Display Key Takeaways section`
- `Display answers`

and click Publish on the Unit in Studio. Assure metrics section, key takeaways section and free-text answers section are visible now.

4. Click on _Download PDF now_ and see that PDF contains only free-text answers and doesn't contain metrics section and key takeaways section (in one of the comments on the ticket, it was suggested that PDF should contain only free-text answers - as it turned out it was an already existing feature, please assure this PR didn't break it :))

**Reviewers**
- [ ] @mtyaka 

Rebased from a994f695b36adb8c82834712f523fb06331123c7.


Signed-off-by: Tomasz Gargas <tomasz@opencraft.com>