### PR TITLE
Enhancements on the freeform-answers report

### DIFF
--- a/eoc_journal/eoc_journal.py
+++ b/eoc_journal/eoc_journal.py
@@ -10,10 +10,12 @@ from lxml import html
 from lxml.html.clean import clean_html
 
 from reportlab.lib import pagesizes
+from reportlab.lib.colors import Color
 from reportlab.lib.styles import getSampleStyleSheet
 from reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer
 
 from problem_builder.models import Answer
+from reportlab.platypus.flowables import HRFlowable
 from xblock.core import XBlock
 from xblock.fields import Boolean, Scope, String, List
 from xblock.fragment import Fragment
@@ -189,6 +191,7 @@ class EOCJournalXBlock(StudioEditableXBlockMixin, XBlock):
             for question in section["questions"]:
                 story.append(Paragraph(question["question"], styles["h2"]))
                 story.append(Paragraph(question["answer"], styles["Normal"]))
+                story.append(HRFlowable(color=Color(0, 0, 0, 0.1), width='100%', spaceBefore=5, spaceAfter=10))
 
         document.build(story)
         pdf_buffer.seek(0)

--- a/eoc_journal/pdf_generator.py
+++ b/eoc_journal/pdf_generator.py
@@ -1,0 +1,185 @@
+"""
+Utils around Reportlab customizations
+"""
+import logging
+
+from reportlab.lib.enums import TA_CENTER
+from reportlab.lib.fonts import tt2ps
+from reportlab.lib.styles import (
+    getSampleStyleSheet,
+    StyleSheet1,
+    ParagraphStyle,
+)
+
+import reportlab
+import reportlab.rl_config
+from reportlab.pdfbase import pdfmetrics
+from reportlab.pdfbase.ttfonts import TTFont, TTFError
+
+log = logging.getLogger(__name__)
+
+
+def get_style_sheet(font_url=None):
+    """Returns a custom stylesheet object"""
+    default_style_sheet = getSampleStyleSheet()
+
+    if not font_url:
+        return default_style_sheet
+
+    stylesheet = StyleSheet1()
+    font_name = 'customFont'
+
+    try:
+        font = TTFont(font_name, font_url)
+    except TTFError:
+        log.warning(u'Cannot load %s', font_url)
+        return default_style_sheet
+
+    reportlab.rl_config.warnOnMissingFontGlyphs = 0
+    pdfmetrics.registerFont(font)
+
+    font_name_bold = tt2ps(font_name, 1, 0)
+    font_name_italic = tt2ps(font_name, 0, 1)
+    font_name_bold_italic = tt2ps(font_name, 1, 1)
+
+    stylesheet.add(ParagraphStyle(
+        name='Normal',
+        fontName=font_name,
+        fontSize=10,
+        leading=12
+    ))
+
+    stylesheet.add(ParagraphStyle(
+        name='BodyText',
+        parent=stylesheet['Normal'],
+        spaceBefore=6
+    ))
+    stylesheet.add(ParagraphStyle(
+        name='Italic',
+        parent=stylesheet['BodyText'],
+        fontName=font_name_italic
+    ))
+
+    stylesheet.add(
+        ParagraphStyle(
+            name='Heading1',
+            parent=stylesheet['Normal'],
+            fontName=font_name_bold,
+            fontSize=18,
+            leading=22,
+            spaceAfter=6
+        ),
+        alias='h1'
+    )
+
+    stylesheet.add(
+        ParagraphStyle(
+            name='Title',
+            parent=stylesheet['Normal'],
+            fontName=font_name_bold,
+            fontSize=22,
+            leading=22,
+            alignment=TA_CENTER,
+            spaceAfter=6
+        ),
+        alias='title'
+    )
+
+    stylesheet.add(
+        ParagraphStyle(
+            name='Heading2',
+            parent=stylesheet['Normal'],
+            fontName=font_name_bold,
+            fontSize=14,
+            leading=18,
+            spaceBefore=12,
+            spaceAfter=6
+        ),
+        alias='h2'
+    )
+
+    stylesheet.add(
+        ParagraphStyle(
+            name='Heading3',
+            parent=stylesheet['Normal'],
+            fontName=font_name_bold_italic,
+            fontSize=12,
+            leading=14,
+            spaceBefore=12,
+            spaceAfter=6
+        ),
+        alias='h3'
+    )
+
+    stylesheet.add(ParagraphStyle(
+        name='Heading4',
+        parent=stylesheet['Normal'],
+        fontName=font_name_bold_italic,
+        fontSize=10,
+        leading=12,
+        spaceBefore=10,
+        spaceAfter=4
+    ),
+        alias='h4'
+    )
+
+    stylesheet.add(ParagraphStyle(
+        name='Heading5',
+        parent=stylesheet['Normal'],
+        fontName=font_name_bold,
+        fontSize=9,
+        leading=10.8,
+        spaceBefore=8,
+        spaceAfter=4
+    ),
+        alias='h5'
+    )
+
+    stylesheet.add(
+        ParagraphStyle(
+            name='Heading6',
+            parent=stylesheet['Normal'],
+            fontName=font_name_bold,
+            fontSize=7,
+            leading=8.4,
+            spaceBefore=6,
+            spaceAfter=2
+        ),
+        alias='h6'
+    )
+
+    stylesheet.add(
+        ParagraphStyle(
+            name='Bullet',
+            parent=stylesheet['Normal'],
+            firstLineIndent=0,
+            spaceBefore=3
+        ),
+        alias='bu'
+    )
+
+    stylesheet.add(
+        ParagraphStyle(
+            name='Definition',
+            parent=stylesheet['Normal'],
+            firstLineIndent=0,
+            leftIndent=36,
+            bulletIndent=0,
+            spaceBefore=6,
+            bulletFontName=font_name_bold_italic
+        ),
+        alias='df'
+    )
+
+    stylesheet.add(
+        ParagraphStyle(
+            name='Code',
+            parent=stylesheet['Normal'],
+            fontName='Courier',
+            fontSize=8,
+            leading=8.8,
+            firstLineIndent=0,
+            leftIndent=36
+        ))
+
+    return stylesheet

--- a/pylintrc
+++ b/pylintrc
@@ -12,4 +12,4 @@ disable=
     locally-disabled
 
 [OPTIONS]
-good-names=_,loader
+good-names=_,loader,log


### PR DESCRIPTION
## Description
This PR contains 3 different enhancements:
- [Horizantal line between questions](https://github.com/open-craft/xblock-eoc-journal/commit/b6f987ece461d2d5de715769c0ae3609fa1fc085):
Appears on all generated reports and there's no custom setting or flow controls it.

- [Default PDF header to Course Title](https://github.com/open-craft/xblock-eoc-journal/commit/6cd863e9b4ae2a5a4d54c90fb047d52229b66dc9):
 Changes made on the `display_name` field where it's now left blank to determine whether to use the Course Title or another custom value.

- [Use custom fonts in generated PDF reports](https://github.com/open-craft/xblock-eoc-journal/commit/7ea5cc69ec341d15d6147b7842efd7048615dcf7):
Users now can specify a url to the desired font and we will generate the report using it. The font can be hosted anywhere on the web, or can be uploaded on Studio. If the url is uploaded on Studio, the user should fill the `custom_font` field with the **_Web_** url not the ~**_Studio_**~ one.

## Tests
- Custom fonts tested.
- PDF custom title tested.

## Screenshot
<img width="827" alt="screen shot 2018-07-25 at 4 04 25 pm" src="https://user-images.githubusercontent.com/11036472/43202868-4b74ea06-9025-11e8-8763-2cc0410c0fa1.png">