### PR TITLE
Allow questions to be empty or invalid XML/HTML

### DIFF
--- a/eoc_journal/eoc_journal.py
+++ b/eoc_journal/eoc_journal.py
@@ -7,6 +7,7 @@ from io import BytesIO
 import webob
 
 from lxml import html
+from lxml.etree import XMLSyntaxError, ParserError
 from lxml.html.clean import clean_html
 
 from reportlab.lib import pagesizes
@@ -232,8 +233,11 @@ class EOCJournalXBlock(StudioEditableXBlockMixin, XBlock):
                 if section not in answers:
                     answers[section] = []
 
-                parsed_question = html.fromstring(block['question'])
-                question = clean_html(parsed_question).text_content()
+                try:
+                    parsed_question = html.fromstring(block['question'])
+                    question = clean_html(parsed_question).text_content()
+                except (XMLSyntaxError, ParserError):
+                    question = block['question']
 
                 answers[section].append({
                     'answer': students_inputs.get(name, _('Not answered yet.')),

--- a/tests/integration/data/course_api_response.json
+++ b/tests/integration/data/course_api_response.json
@@ -120,12 +120,25 @@
             "type": "pb-answer",
             "id": "i4x://Org/Course/pb-answer/6f070c350e39429cbccfd3185a33621c"
         },
+        "i4x://Org/Course/pb-answer/927c5b8cd051475e937b8c1091a9feaf": {
+            "display_name": "More Introductions",
+            "block_id": "927c5b8cd051475e937b8c1091a9feaf",
+            "student_view_url": "http://example.com/xblock/i4x://Org/Course/pb-answer/927c5b8cd051475e937b8c1091a9feaf",
+            "student_view_data": {
+                "question": "",
+                "name": "c26b280"
+            },
+            "lms_web_url": "http://example.com/courses/Org/Course/Run/jump_to/i4x://Org/Course/pb-answer/927c5b8cd051475e937b8c1091a9feaf",
+            "type": "pb-answer",
+            "id": "i4x://Org/Course/pb-answer/927c5b8cd051475e937b8c1091a9feaf"
+        },
         "i4x://Org/Course/vertical/8f995fb218664104bb3f898f10744511": {
             "display_name": "Unit 1",
             "block_id": "8f995fb218664104bb3f898f10744511",
             "children": [
                 "i4x://Org/Course/pb-answer/6f070c350e39429cbccfd3185a33621c",
-                "i4x://Org/Course/pb-answer/a0b04a13d3074229b6be33fbc31de233"
+                "i4x://Org/Course/pb-answer/a0b04a13d3074229b6be33fbc31de233",
+                "i4x://Org/Course/pb-answer/927c5b8cd051475e937b8c1091a9feaf"
             ],
             "student_view_url": "http://example.com/xblock/i4x://Org/Course/vertical/8f995fb218664104bb3f898f10744511",
             "lms_web_url": "http://example.com/courses/Org/Course/Run/jump_to/i4x://Org/Course/vertical/8f995fb218664104bb3f898f10744511",

--- a/tests/integration/test_eoc_journal.py
+++ b/tests/integration/test_eoc_journal.py
@@ -51,6 +51,7 @@ default_pb_answer_block_ids = [
     'i4x://Org/Course/pb-answer/b86edf60454b47dbb8f2e1b4e2d48d6a',
     'i4x://Org/Course/pb-answer/6f070c350e39429cbccfd3185a33621c',
     'i4x://Org/Course/pb-answer/a0b04a13d3074229b6be33fbc31de233',
+    'i4x://Org/Course/pb-answer/927c5b8cd051475e937b8c1091a9feaf',
 ]
 
 
@@ -63,6 +64,7 @@ default_answers_data = [
 expected_answers_data = [
     {'question': u'Hello, who are you? What\u2019s your name?', 'answer': 'Not answered yet.'},
     {'question': u'Tell us more about yourself.', 'answer': 'student input'},
+    {'question': u'', 'answer': 'Not answered yet.'},
 ]
 
 
@@ -333,8 +335,8 @@ class TestEOCJournal(StudioEditableBaseTest):
 
         field_control = self.get_element_for_pb_answers_field()
         items = field_control.find_elements_by_css_selector('.list-settings-item')
-        # There are three pb-answer blocks in the mocked course blocks API response.
-        self.assertEqual(len(items), 3)
+        # There are four pb-answer blocks in the mocked course blocks API response.
+        self.assertEqual(len(items), 4)
         expected_choices = [
             {
                 'value': default_pb_answer_block_ids[0],
@@ -342,11 +344,15 @@ class TestEOCJournal(StudioEditableBaseTest):
             },
             {
                 'value': default_pb_answer_block_ids[1],
-                'title': 'Second Section / Subsection 2 / Unit 1 / Introductions'
+                'title': 'Second Section / Subsection 2 / Unit 1 / Introductions',
             },
             {
                 'value': default_pb_answer_block_ids[2],
-                'title': 'Second Section / Subsection 2 / Unit 1 / More Info'
+                'title': 'Second Section / Subsection 2 / Unit 1 / More Info',
+            },
+            {
+                'value': default_pb_answer_block_ids[3],
+                'title': 'Second Section / Subsection 2 / Unit 1 / More Introductions',
             },
         ]
         for idx, item in enumerate(items):
@@ -382,7 +388,7 @@ class TestEOCJournal(StudioEditableBaseTest):
         self.assertEqual(section_name.text, 'Second Section')
 
         answers_in_section = items[0].find_elements_by_css_selector('.eoc-selected-answer')
-        self.assertEqual(len(answers_in_section), 2)
+        self.assertEqual(len(answers_in_section), 3)
 
         for element, expected in zip(answers_in_section, expected_answers_data):
             question = element.find_element_by_css_selector('h5')


### PR DESCRIPTION
A recent PR (https://github.com/open-craft/xblock-eoc-journal/pull/13) added support for stripping HTML tags from the question text when rendering in the Course Journal. This inadvertently made it an error to have empty question test, or question text that contains broken content that would cause a parsing error. 

This PR fixes that by falling back to the original question text in case of a parsing error. 

**Testing instructions:**
1. Create a course that uses the eoc-journal.
2. Add a problem-builder long-form question that has no question text.
3. Include this question in the list of questions for the course journal. 
4. As a student submit an answer for a problem that has not question text. 
5. Visit the page with the course journal. It should not throw an error. 