### PR TITLE
BB-1126 Map block ids into correct course ids when importing XML

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -24,3 +24,4 @@ six
 web-fragments
 webob
 XBlock
+edx-opaque-keys==0.4.4

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def package_data(pkg, roots):
 
 setup(
     name='xblock-eoc-journal',
-    version='0.2',
+    version='0.3',
     description='End of Course Journal XBlock',
     packages=[
         'eoc_journal',

--- a/tests/unit/test_import.py
+++ b/tests/unit/test_import.py
@@ -1,0 +1,32 @@
+"""
+Test EOC Journal Block import.
+"""
+
+import unittest
+from mock import Mock, patch
+from django.test import TestCase
+from eoc_journal.eoc_journal import EOCJournalXBlock
+
+
+class TestEOCJournalImport(TestCase):
+    """
+    Test End of Course Journal Import
+    """
+
+    @patch('eoc_journal.eoc_journal.XBlock.parse_xml',
+        return_value=Mock(autospec=EOCJournalXBlock)
+    )
+    def test_parse_xml(self, mock_xblock_parse_xml):
+        mock_xblock_parse_xml().selected_pb_answer_blocks = [
+            'i4x://Org/Course/pb-answer/b86edf60454b47dbb8f2e1b4e2d48d6a',
+            'i4x://Org/Course/pb-answer/6f070c350e39429cbccfd3185a33621c',
+            'i4x://Org/Course/pb-answer/a0b04a13d3074229b6be33fbc31de233',
+            'i4x://Org/Course/pb-answer/927c5b8cd051475e937b8c1091a9feaf',
+        ]
+        mock_node = Mock()
+        mock_runtime = Mock()
+        mock_keys = Mock()
+        mock_id_generator = Mock(target_course_id='Org/CourseToImport/2014')
+        block = EOCJournalXBlock.parse_xml(mock_node, mock_runtime, mock_keys, mock_id_generator)
+        for block_id in block.selected_pb_answer_blocks:
+            self.assertTrue(block_id.startswith('i4x://Org/CourseToImport'))


### PR DESCRIPTION
The EOC uses the [block id](https://github.com/open-craft/xblock-eoc-journal/blob/master/eoc_journal/eoc_journal.py#L354) to [keep track](https://github.com/open-craft/xblock-eoc-journal/blob/master/eoc_journal/eoc_journal.py#L58) of the selected problems to appear in the journal.
The block id is essentially the [block location](https://github.com/open-craft/xblock-eoc-journal/blob/master/tests/integration/test_eoc_journal.py#L53) which is bound to a specific course name.

This PR uses [`UsageKey.map_into_course` method](https://github.com/edx/opaque-keys/blob/master/opaque_keys/edx/keys.py#L95) to re-map each block location key to the target course id when importing a course. This is done by overriding [`parse_xml` xblock method](https://github.com/edx/XBlock/blob/master/xblock/mixins.py#L432).

## Testing instructions:

1. Create (or go to) a course with [Problem Builder](https://github.com/open-craft/problem-builder) freeform answer blocks.
2. Create (or go to) a EOC block and select some of the problem builder freeform answers listed to report.
3. Save the course outline and export the entire course.
4. Create another, empty course.
5. Import the previously exported course.
6. Make sure the **selected** problem builder freeform answers listed in the EOC block in the outline are the same as the ones that are selected in the exported course.