### PR TITLE
[BB-2132] [YONK-1560] Support JWT creation on openedx ironwood

### DIFF
--- a/eoc_journal/compat.py
+++ b/eoc_journal/compat.py
@@ -1,0 +1,14 @@
+"""
+edx-platform dependent code
+"""
+# pylint: disable=import-error
+
+
+def create_jwt_for_user(user):
+    """
+    Wraps openedx.core.djangoapps.oauth_dispatch.jwt.create_jwt_for_user() call
+    """
+    # test env does not have edx-platform installed. because of this, all edx-platform imports must be
+    # kept inside this function so that the test code does not break when importing the module
+    from openedx.core.djangoapps.oauth_dispatch.jwt import create_jwt_for_user as openedx_create_jwt_for_user
+    return openedx_create_jwt_for_user(user)

--- a/eoc_journal/utils.py
+++ b/eoc_journal/utils.py
@@ -2,6 +2,8 @@
 
 from edx_rest_api_client.client import EdxRestApiClient
 
+from .compat import create_jwt_for_user
+
 
 def normalize_id(key):
     """
@@ -27,9 +29,6 @@ def build_jwt_edx_client(url, scopes, user, expires_in, append_slash=True):
     Returns an edx API client authorized using JWT.
     """
 
-    # test env does not have edx-platform installed. because of this, all edx-platform imports must be
-    # kept inside this function so that the test code does not break when importing the module
-    from openedx.core.djangoapps.oauth_dispatch.jwt import create_jwt_for_user  # pylint: disable=import-error
     jwt = create_jwt_for_user(user)
     return EdxRestApiClient(url, append_slash=append_slash, jwt=jwt)
 

--- a/eoc_journal/utils.py
+++ b/eoc_journal/utils.py
@@ -2,8 +2,6 @@
 
 from edx_rest_api_client.client import EdxRestApiClient
 
-from openedx.core.djangoapps.oauth_dispatch.jwt import create_jwt_for_user
-
 
 def normalize_id(key):
     """
@@ -29,6 +27,9 @@ def build_jwt_edx_client(url, scopes, user, expires_in, append_slash=True):
     Returns an edx API client authorized using JWT.
     """
 
+    # test env does not have edx-platform installed. because of this, all edx-platform imports must be
+    # kept inside this function so that the test code does not break when importing the module
+    from openedx.core.djangoapps.oauth_dispatch.jwt import create_jwt_for_user  # pylint: disable=import-error
     jwt = create_jwt_for_user(user)
     return EdxRestApiClient(url, append_slash=append_slash, jwt=jwt)
 

--- a/eoc_journal/utils.py
+++ b/eoc_journal/utils.py
@@ -2,10 +2,7 @@
 
 from edx_rest_api_client.client import EdxRestApiClient
 
-try:
-    from openedx.core.lib.token_utils import JwtBuilder  # pylint: disable=F0401
-except ImportError:
-    JwtBuilder = None  # pylint: disable=C0103
+from openedx.core.djangoapps.oauth_dispatch.jwt import create_jwt_for_user
 
 
 def normalize_id(key):
@@ -31,9 +28,8 @@ def build_jwt_edx_client(url, scopes, user, expires_in, append_slash=True):
     """
     Returns an edx API client authorized using JWT.
     """
-    if JwtBuilder is None:
-        raise NotConnectedToOpenEdX("This package must be installed in an OpenEdX environment.")
-    jwt = JwtBuilder(user).build_token(scopes, expires_in)
+
+    jwt = create_jwt_for_user(user)
     return EdxRestApiClient(url, append_slash=append_slash, jwt=jwt)
 
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -13,7 +13,7 @@ fs
 lxml
 mako
 markupsafe
-pdfminer
+pdfminer==20140328
 pycodestyle
 pylint
 python-dateutil

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def package_data(pkg, roots):
 
 setup(
     name='xblock-eoc-journal',
-    version='0.4',
+    version='0.5',
     description='End of Course Journal XBlock',
     packages=[
         'eoc_journal',


### PR DESCRIPTION
Problem root cause: JwtBuilder class was removed in commit dc56a63e of edx-platform
git repository and the eoc-journal xblock was not updated accordingly.