### PR TITLE
[MCKIN-24505] [BB-2993] Switch to using plain requests and remove depricated EdxRestApiClient

### DIFF
--- a/eoc_journal/api_client.py
+++ b/eoc_journal/api_client.py
@@ -63,7 +63,7 @@ class ApiClient(BaseApiClient):
         the current course.
         """
         try:
-            course = self.client.courses(id=self.course_id).get(depth=5)
+            course = self.client.get(self.api_url + '/courses', params={"depth": 5}).json()
         except HttpClientError:
             return None
 

--- a/eoc_journal/base_api_client.py
+++ b/eoc_journal/base_api_client.py
@@ -30,9 +30,4 @@ class BaseApiClient(object):
         """
         Connect to the REST API, authenticating with a JWT for the current user.
         """
-        scopes = ['profile', 'email']
-
-        self.client = build_jwt_edx_client(
-            self.api_url, scopes, self.user,
-            self.expires_in, append_slash=True
-        )
+        self.client = build_jwt_edx_client(self.user)

--- a/eoc_journal/completion_api.py
+++ b/eoc_journal/completion_api.py
@@ -16,9 +16,12 @@ class CompletionApiClient(BaseApiClient):
         """
         Fetches and returns the progress percentage for the current user.
         """
-        course_api = self.client.course(self.course_id)
+        url = "{base_url}/course/{course_id}".format(
+            base_url=self.api_url,
+            course_id=self.course_id,
+        )
         try:
-            data = course_api.get(username=self.user.username, **kwargs)
+            data = self.client.get(url, params=dict(username=self.user.username, **kwargs)).json()
             return data['results'][0]['completion']['percent'] * 100
         except (HttpClientError, IndexError):
             return None

--- a/eoc_journal/course_blocks_api.py
+++ b/eoc_journal/course_blocks_api.py
@@ -16,4 +16,7 @@ class CourseBlocksApiClient(BaseApiClient):
         """
         Fetches and returns blocks from the Course API.
         """
-        return self.client.blocks.get(course_id=self.course_id, **kwargs)
+        return self.client.get(
+            self.api_url + '/blocks',
+            params=dict(course_id=self.course_id, **kwargs)
+        ).json()

--- a/eoc_journal/utils.py
+++ b/eoc_journal/utils.py
@@ -1,6 +1,7 @@
 """EOC Journal XBlock - Utils"""
 
-from edx_rest_api_client.client import EdxRestApiClient
+from edx_rest_api_client.auth import SuppliedJwtAuth
+from requests import Session
 
 from .compat import create_jwt_for_user
 
@@ -24,13 +25,15 @@ def _(text):
     return text
 
 
-def build_jwt_edx_client(url, scopes, user, expires_in, append_slash=True):
+def build_jwt_edx_client(user):
     """
     Returns an edx API client authorized using JWT.
     """
 
     jwt = create_jwt_for_user(user)
-    return EdxRestApiClient(url, append_slash=append_slash, jwt=jwt)
+    session = Session()
+    session.auth = SuppliedJwtAuth(jwt)
+    return session
 
 
 def ngettext_fallback(text_singular, text_plural, number):

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def package_data(pkg, roots):
 
 setup(
     name='xblock-eoc-journal',
-    version='0.7.2',
+    version='0.8.0',
     description='End of Course Journal XBlock',
     packages=[
         'eoc_journal',


### PR DESCRIPTION
EdxRestApiClient is deprecated since it's based on slumber which is no longer supported. It is also throwing errors on Python 3. 

This PR switches to using JWT directly with the requests library for API requests. 

**Testing Instructions**
- Install the PR version of this XBlock
- Enable all features of the block in studio. 
- Make sure the block works in the LMS. 
- Ensure that it reports the same results as Apros. 