### PR TITLE
[BB-3164] [MCKIN-27010] Fix import error in eoc-journal

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -14,9 +14,9 @@ jobs:
             virtualenv venv
             . venv/bin/activate
             pip install -U pip wheel
-            pip install -r requirements-test.txt
-            pip install -r venv/src/xblock-sdk/requirements/base.txt
-            pip install -r venv/src/xblock-sdk/requirements/test.txt
+            pip install -r requirements-test.txt --exists-action w
+            pip install -r venv/src/xblock-sdk/requirements/base.txt --exists-action w
+            pip install -r venv/src/xblock-sdk/requirements/test.txt --exists-action w
             mkdir var
       - save_cache:
           key: dependencies-{{ checksum "circle.yml" }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-test.txt" }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,1 @@
-xblock-utils==1.2.2
--e 'git+https://github.com/open-craft/problem-builder@v3.5.5#egg=xblock-problem-builder==v3.5.5 ; python_version < "3"'
--e 'git+https://github.com/open-craft/problem-builder@v4.1.5#egg=xblock-problem-builder==v4.1.5 ; python_version >= "3"'
-edx-rest-api-client==1.6.0
-reportlab==3.1.44
-future==0.18.2
-six
 -e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
+-e 'git+https://github.com/open-craft/problem-builder@v3.5.5#egg=xblock-problem-builder==v3.5.5 ; python_version < "3"'
+-e 'git+https://github.com/open-craft/problem-builder@v4.1.5#egg=xblock-problem-builder==v4.1.5 ; python_version >= "3"'
 -e .

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def package_data(pkg, roots):
 
 setup(
     name='xblock-eoc-journal',
-    version='0.9.1',
+    version='0.9.2',
     description='End of Course Journal XBlock',
     packages=[
         'eoc_journal',

--- a/setup.py
+++ b/setup.py
@@ -29,18 +29,18 @@ setup(
     ],
     install_requires=[
         'XBlock',
-        'xblock-utils==1.2.2',
-        'edx-rest-api-client==1.6.0',
+        'xblock-utils',
+        'edx-rest-api-client',
         'reportlab==3.1.44',
         'future',
         'six'
     ],
     extras_require={
         ":python_version<'3'": [
-            "xblock-problem-builder==3.5.5"
+            "xblock-problem-builder<4"
         ],
         ":python_version>='3'": [
-            "xblock-problem-builder==4.1.5"
+            "xblock-problem-builder>=4.1.5"
         ]
     },
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         'xblock-utils==1.2.2',
         'edx-rest-api-client==1.6.0',
         'reportlab==3.1.44',
-        'future==0.18.2',
+        'future',
         'six'
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -29,12 +29,20 @@ setup(
     ],
     install_requires=[
         'XBlock',
-        'xblock-utils',
-        'edx-rest-api-client',
-        'reportlab',
-        'xblock-problem-builder',
-        'six',
+        'xblock-utils==1.2.2',
+        'edx-rest-api-client==1.6.0',
+        'reportlab==3.1.44',
+        'future==0.18.2',
+        'six'
     ],
+    extras_require={
+        ":python_version<'3'": [
+            "xblock-problem-builder==3.5.5"
+        ],
+        ":python_version>='3'": [
+            "xblock-problem-builder==4.1.5"
+        ]
+    },
     entry_points={
         'xblock.v1': [
             'eoc-journal = eoc_journal:EOCJournalXBlock',


### PR DESCRIPTION
This PR fixes the following import error that appeared due to the latest version of ``reportlab`` - 

```
ImportError: reportlab requires Python 2.7+ or 3.6+; other versions are unsupported.
```

**JIRA tickets**: https://tasks.opencraft.com/browse/BB-3164

**Discussions**: N/A

**Dependencies**: None

~~**Screenshots**:~~ 
~~**Sandbox URL**:~~

**Merge deadline**: ASAP

**Testing instructions**:

1. Install this PR version to a devstack in both LMS and studio
2. Enable xblock-eoc-journal from studio
3. Studio and LMS should work correctly without any import error

**Author notes and concerns**:

1. Using ``setup.py`` for specifying dependency version instead of ``requirements.txt``, so that it stays same while installing from ``requirements.txt`` or via ``pip install -e .`` command

**Reviewers**
- [ ] @xitij2000 

~~**Settings**~~
