### PR TITLE
MCKIN-32454: use edx-rest-api-client >= 5.2.1 to match juniper and higher releases

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -26,6 +26,7 @@ web-fragments==0.3.1
 webob
 XBlock==1.2.9
 edx-opaque-keys==0.4.4
+edx-django-utils==3.13.0
 
 # Latest version(1.0.4) of django-appconf do not support python 2
 django-appconf==1.0.3

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def package_data(pkg, roots):
 
 setup(
     name='xblock-eoc-journal',
-    version='0.10.0',
+    version='0.10.1',
     description='End of Course Journal XBlock',
     packages=[
         'eoc_journal',
@@ -30,7 +30,7 @@ setup(
     install_requires=[
         'XBlock',
         'xblock-utils',
-        'edx-rest-api-client==1.9.2',
+        'edx-rest-api-client>=5.2.1,<5.3.0',
         'reportlab==3.1.44',
         'future',
         'six'


### PR DESCRIPTION
Juniper release installs version` 5.2.1` of `edx-rest-api-client`. Because this repo has `edx-rest-api-client` pinned to `1.9.2` it raises a build error on platform. 
`ERROR: xblock-eoc-journal 0.10.0 has requirement edx-rest-api-client==1.9.2, but you'll have edx-rest-api-client 5.2.1 which is incompatible.
`